### PR TITLE
(#103) cleanup flow simulator

### DIFF
--- a/examples/2d_examples/FlowPastCylinderCase/flow_past_cylinder.py
+++ b/examples/2d_examples/FlowPastCylinderCase/flow_past_cylinder.py
@@ -32,18 +32,16 @@ def flow_past_cylinder_boundary_forcing_case(
     cyl_radius = 0.03
     nu = cyl_radius * velocity_scale / reynolds
     x_range = 1.0
-
-    flow_sim = sps.UnboundedFlowSimulator2D(
+    flow_sim = sps.UnboundedNavierStokesFlowSimulator2D(
         grid_size=grid_size,
         x_range=x_range,
         kinematic_viscosity=nu,
-        flow_type="navier_stokes_with_forcing",
+        with_forcing=True,
         with_free_stream_flow=True,
         real_t=real_t,
         num_threads=num_threads,
         time=0.0,
     )
-
     # Initialize fixed cylinder (elastica rigid body) with direction along Z
     x_cm = 2.5 * cyl_radius
     y_cm = 0.5 * grid_size_y / grid_size_x

--- a/examples/2d_examples/FlowPastRodCase/flow_past_rod.py
+++ b/examples/2d_examples/FlowPastRodCase/flow_past_rod.py
@@ -101,11 +101,11 @@ def flow_past_rod_case(
     # Flow parameters
     # Re = velocity_free_stream * base_length / nu
     nu = base_length * velocity_free_stream / reynolds
-    flow_sim = sps.UnboundedFlowSimulator2D(
+    flow_sim = sps.UnboundedNavierStokesFlowSimulator2D(
         grid_size=(grid_size_y, grid_size_x),
         x_range=x_range,
         kinematic_viscosity=nu,
-        flow_type="navier_stokes_with_forcing",
+        with_forcing=True,
         with_free_stream_flow=True,
         real_t=real_t,
         num_threads=num_threads,

--- a/examples/2d_examples/ImmersedContinuumSnakeCase/immersed_continuum_snake.py
+++ b/examples/2d_examples/ImmersedContinuumSnakeCase/immersed_continuum_snake.py
@@ -86,11 +86,11 @@ def immersed_continuum_snake_case(
     # Flow parameters
     vel_scale = base_length / period
     nu = base_length * vel_scale / reynolds
-    flow_sim = sps.UnboundedFlowSimulator2D(
+    flow_sim = sps.UnboundedNavierStokesFlowSimulator2D(
         grid_size=grid_size,
         x_range=x_range,
         kinematic_viscosity=nu,
-        flow_type="navier_stokes_with_forcing",
+        with_forcing=True,
         real_t=real_t,
         num_threads=num_threads,
     )

--- a/examples/2d_examples/ImmersedFlexiblePendulumCases/immersed_flexible_pendulum_with_rigid_cylinder.py
+++ b/examples/2d_examples/ImmersedFlexiblePendulumCases/immersed_flexible_pendulum_with_rigid_cylinder.py
@@ -91,11 +91,11 @@ def immersed_flexible_pendulum_with_rigid_cylinder_case(
     vel_scale = np.sqrt(np.fabs(gravitational_acc) * rod_length)
     Re = 500
     nu = rod_length * vel_scale / Re
-    flow_sim = sps.UnboundedFlowSimulator2D(
+    flow_sim = sps.UnboundedNavierStokesFlowSimulator2D(
         grid_size=grid_size,
         x_range=x_range,
         kinematic_viscosity=nu,
-        flow_type="navier_stokes_with_forcing",
+        with_forcing=True,
         real_t=real_t,
         num_threads=num_threads,
     )

--- a/examples/2d_examples/LambOseenVortexCase/lamb_oseen_vortex.py
+++ b/examples/2d_examples/LambOseenVortexCase/lamb_oseen_vortex.py
@@ -128,22 +128,6 @@ def lamb_oseen_vortex_flow_case(
     print(f"Final vortex center location: ({x_cm_final}, {y_cm_final})")
     print(f"vorticity L2 error: {l2_error}")
     print(f"vorticity Linf error: {linf_error}")
-    final_analytical_velocity_field = compute_lamb_oseen_velocity(
-        x=flow_sim.position_field[x_axis_idx],
-        y=flow_sim.position_field[y_axis_idx],
-        x_cm=x_cm_final,
-        y_cm=y_cm_final,
-        nu=nu,
-        gamma=gamma,
-        t=t_end,
-        real_t=real_t,
-    )
-    flow_sim.compute_velocity_from_vorticity()
-    error_field = np.fabs(flow_sim.velocity_field - final_analytical_velocity_field)
-    l2_error = np.linalg.norm(error_field) * flow_sim.dx
-    linf_error = np.amax(error_field)
-    print(f"velocity L2 error: {l2_error}")
-    print(f"velocity Linf error: {linf_error}")
 
 
 if __name__ == "__main__":

--- a/examples/2d_examples/LambOseenVortexCase/lamb_oseen_vortex.py
+++ b/examples/2d_examples/LambOseenVortexCase/lamb_oseen_vortex.py
@@ -27,17 +27,16 @@ def lamb_oseen_vortex_flow_case(
     t_end = 1.4
     # to start with max circulation = 1
     gamma = 4 * np.pi * nu * t_start
-    flow_sim = sps.UnboundedFlowSimulator2D(
+    flow_sim = sps.UnboundedNavierStokesFlowSimulator2D(
         grid_size=grid_size,
         x_range=x_range,
         kinematic_viscosity=nu,
-        flow_type="navier_stokes",
+        with_forcing=False,
         with_free_stream_flow=True,
         real_t=real_t,
         num_threads=num_threads,
         time=t_start,
     )
-
     flow_sim.vorticity_field[...] = compute_lamb_oseen_vorticity(
         x=flow_sim.position_field[x_axis_idx],
         y=flow_sim.position_field[y_axis_idx],

--- a/examples/2d_examples/LidDrivenCavityCase/lid_driven_cavity_case.py
+++ b/examples/2d_examples/LidDrivenCavityCase/lid_driven_cavity_case.py
@@ -27,15 +27,14 @@ def lid_driven_cavity_case(
     ldc_side_length = 0.6
     nu = ldc_side_length * lid_velocity / reynolds
     x_range = 1.0
-    flow_sim = sps.UnboundedFlowSimulator2D(
+    flow_sim = sps.UnboundedNavierStokesFlowSimulator2D(
         grid_size=grid_size,
         x_range=x_range,
         kinematic_viscosity=nu,
-        flow_type="navier_stokes_with_forcing",
+        with_forcing=True,
         real_t=real_t,
         num_threads=num_threads,
     )
-
     # Initialize lid driven cavity forcing grid
     num_lag_nodes_per_side = grid_size[x_axis_idx] * 3 // 8
     ldc_com = (0.5, 0.5)

--- a/examples/2d_examples/OctopusArmCase/run_coupling_tapered_arm_and_cylinder.py
+++ b/examples/2d_examples/OctopusArmCase/run_coupling_tapered_arm_and_cylinder.py
@@ -66,11 +66,11 @@ def tapered_arm_and_cylinder_flow_coupling(
     # Flow parameters
     vel_scale = base_length / period
     nu = base_length * vel_scale / reynolds
-    flow_sim = sps.UnboundedFlowSimulator2D(
+    flow_sim = sps.UnboundedNavierStokesFlowSimulator2D(
         grid_size=grid_size,
         x_range=x_range,
         kinematic_viscosity=nu,
-        flow_type="navier_stokes_with_forcing",
+        with_forcing=True,
         real_t=real_t,
         num_threads=num_threads,
     )

--- a/examples/2d_examples/VortexInducedFlagFlappingCase/turek_and_hron_benchmark.py
+++ b/examples/2d_examples/VortexInducedFlagFlappingCase/turek_and_hron_benchmark.py
@@ -99,11 +99,11 @@ def flow_past_rod_case(
     # Re = velocity_free_stream * cyl_diameter / nu
     cyl_diameter = base_length * cyl_diameter_to_rod_length
     nu = cyl_diameter * velocity_free_stream / reynolds
-    flow_sim = sps.UnboundedFlowSimulator2D(
+    flow_sim = sps.UnboundedNavierStokesFlowSimulator2D(
         grid_size=grid_size,
         x_range=x_range,
         kinematic_viscosity=nu,
-        flow_type="navier_stokes_with_forcing",
+        with_forcing=True,
         with_free_stream_flow=True,
         real_t=real_t,
         num_threads=num_threads,

--- a/examples/3d_examples/ElasticNetCase/immersed_elastic_net.py
+++ b/examples/3d_examples/ElasticNetCase/immersed_elastic_net.py
@@ -38,11 +38,11 @@ def immersed_elastic_net_case(
         * vel_free_stream
         / reynolds
     )
-    flow_sim = sps.UnboundedFlowSimulator3D(
+    flow_sim = sps.UnboundedNavierStokesFlowSimulator3D(
         grid_size=grid_size,
         x_range=domain_x_range,
         kinematic_viscosity=kinematic_viscosity,
-        flow_type="navier_stokes_with_forcing",
+        with_forcing=True,
         with_free_stream_flow=True,
         real_t=real_t,
         num_threads=num_threads,

--- a/examples/3d_examples/FlowPastRodCase/flow_past_rod_case.py
+++ b/examples/3d_examples/FlowPastRodCase/flow_past_rod_case.py
@@ -99,11 +99,11 @@ def flow_past_rod_case(
 
     # ==================FLOW SETUP START=========================
     kinematic_viscosity = U_free_stream * base_diameter / reynolds
-    flow_sim = sps.UnboundedFlowSimulator3D(
+    flow_sim = sps.UnboundedNavierStokesFlowSimulator3D(
         grid_size=grid_size,
         x_range=x_range,
         kinematic_viscosity=kinematic_viscosity,
-        flow_type="navier_stokes_with_forcing",
+        with_forcing=True,
         with_free_stream_flow=True,
         real_t=real_t,
         num_threads=num_threads,

--- a/examples/3d_examples/FlowPastSphereCase/flow_past_sphere_case.py
+++ b/examples/3d_examples/FlowPastSphereCase/flow_past_sphere_case.py
@@ -28,13 +28,13 @@ def flow_past_sphere_case(
     far_field_velocity = 1.0
     sphere_diameter = 0.4 * min(grid_size_z, grid_size_y) / grid_size_x * x_range
     nu = far_field_velocity * sphere_diameter / reynolds
-    flow_sim = sps.UnboundedFlowSimulator3D(
+    flow_sim = sps.UnboundedNavierStokesFlowSimulator3D(
         grid_size=grid_size,
         x_range=x_range,
         kinematic_viscosity=nu,
         real_t=real_t,
         num_threads=num_threads,
-        flow_type="navier_stokes_with_forcing",
+        with_forcing=True,
         with_free_stream_flow=True,
         time=0.0,
         # filter_vorticity=True,

--- a/examples/3d_examples/FlowThroughPipeCase/flow_through_circular_pipe_case.py
+++ b/examples/3d_examples/FlowThroughPipeCase/flow_through_circular_pipe_case.py
@@ -29,11 +29,11 @@ def flow_through_circular_pipe_case(
     z_axis_idx = spu.VectorField.z_axis_idx()
     x_range = 1.0
     nu = 1e-2
-    flow_sim = sps.UnboundedFlowSimulator3D(
+    flow_sim = sps.UnboundedNavierStokesFlowSimulator3D(
         grid_size=grid_size,
         x_range=x_range,
         kinematic_viscosity=nu,
-        flow_type="navier_stokes_with_forcing",
+        with_forcing=True,
         with_free_stream_flow=True,
         real_t=real_t,
         num_threads=num_threads,

--- a/examples/3d_examples/HillSphericalVortexCase/hill_sphere_vortex_case.py
+++ b/examples/3d_examples/HillSphericalVortexCase/hill_sphere_vortex_case.py
@@ -23,11 +23,10 @@ def hill_sphere_vortex_case(
     z_axis_idx = spu.VectorField.z_axis_idx()
     # Consider a 1 by 1 by 1 3D domain
     x_range = 1.0
-    flow_sim = sps.UnboundedFlowSimulator3D(
+    flow_sim = sps.UnboundedNavierStokesFlowSimulator3D(
         grid_size=grid_size,
         x_range=x_range,
         kinematic_viscosity=0.0,
-        flow_type="navier_stokes",
         real_t=real_t,
         num_threads=num_threads,
     )

--- a/examples/3d_examples/MagneticCiliaCarpetCase/immersed_magnetic_cilia_carpet.py
+++ b/examples/3d_examples/MagneticCiliaCarpetCase/immersed_magnetic_cilia_carpet.py
@@ -32,11 +32,11 @@ def immersed_magnetic_cilia_carpet_case(
         * cilia_carpet_simulator.velocity_scale
         / reynolds
     )
-    flow_sim = sps.UnboundedFlowSimulator3D(
+    flow_sim = sps.UnboundedNavierStokesFlowSimulator3D(
         grid_size=grid_size,
         x_range=domain_x_range,
         kinematic_viscosity=kinematic_viscosity,
-        flow_type="navier_stokes_with_forcing",
+        with_forcing=True,
         real_t=real_t,
         num_threads=num_threads,
         filter_vorticity=True,

--- a/examples/3d_examples/OctopusArmCase3D/run_tapered_arm_and_sphere_with_flow.py
+++ b/examples/3d_examples/OctopusArmCase3D/run_tapered_arm_and_sphere_with_flow.py
@@ -126,11 +126,11 @@ def tapered_arm_and_cylinder_flow_coupling(
     # ==================FLOW SETUP START=========================
     # Flow parameters
     kinematic_viscosity = base_diameter * vel_scale / reynolds_number
-    flow_sim = sps.UnboundedFlowSimulator3D(
+    flow_sim = sps.UnboundedNavierStokesFlowSimulator3D(
         grid_size=grid_size,
         x_range=x_range,
         kinematic_viscosity=kinematic_viscosity,
-        flow_type="navier_stokes_with_forcing",
+        with_forcing=True,
         with_free_stream_flow=False,
         real_t=real_t,
         num_threads=num_threads,

--- a/examples/3d_examples/PointSourceAdvectAndDiffuseCase/point_source_advection_diffusion.py
+++ b/examples/3d_examples/PointSourceAdvectAndDiffuseCase/point_source_advection_diffusion.py
@@ -26,22 +26,23 @@ def point_source_advection_diffusion_case(
     # start with non-zero to avoid singularity in point source
     t_start = 5.0
     t_end = 5.4
-    # init vortex at (0.3 0.3, 0.3)
-    flow_sim = sps.UnboundedFlowSimulator3D(
+    flow_sim = sps.PassiveTransportFlowSimulator(
+        kinematic_viscosity=nu,
+        grid_dim=grid_dim,
         grid_size=grid_size,
         x_range=x_range,
-        kinematic_viscosity=nu,
-        flow_type="passive_vector",
         real_t=real_t,
         num_threads=num_threads,
         time=t_start,
+        field_type="vector",
     )
+    # init vortex at (0.3 0.3, 0.3)
     x_cm_start = 0.3
     y_cm_start = x_cm_start
     z_cm_start = x_cm_start
     # to start with point source magnitude = 1
     point_mag = 4.0 * np.pi * nu * t_start**1.5
-    vorticity_field = flow_sim.primary_vector_field.view()
+    vorticity_field = flow_sim.primary_field.view()
     for i in range(grid_dim):
         vorticity_field[i] = compute_diffused_point_source_field(
             x_grid=flow_sim.position_field[x_axis_idx],

--- a/sopht/simulator/flow/__init__.py
+++ b/sopht/simulator/flow/__init__.py
@@ -2,4 +2,7 @@ from .flow_simulators_2d import UnboundedFlowSimulator2D
 from .flow_simulators_3d import UnboundedFlowSimulator3D
 from .flow_simulators import FlowSimulator
 from .passive_transport_flow_simulators import PassiveTransportFlowSimulator
-from .navier_stokes_flow_simulators import UnboundedNavierStokesFlowSimulator2D
+from .navier_stokes_flow_simulators import (
+    UnboundedNavierStokesFlowSimulator2D,
+    UnboundedNavierStokesFlowSimulator3D,
+)

--- a/sopht/simulator/flow/__init__.py
+++ b/sopht/simulator/flow/__init__.py
@@ -1,2 +1,5 @@
 from .flow_simulators_2d import UnboundedFlowSimulator2D
 from .flow_simulators_3d import UnboundedFlowSimulator3D
+from .flow_simulators import FlowSimulator
+from .passive_transport_flow_simulators import PassiveTransportFlowSimulator
+from .navier_stokes_flow_simulators import UnboundedNavierStokesFlowSimulator2D

--- a/sopht/simulator/flow/flow_simulators.py
+++ b/sopht/simulator/flow/flow_simulators.py
@@ -1,0 +1,131 @@
+import logging
+import numpy as np
+from typing import Type
+
+
+class FlowSimulator:
+    """Class for base flow simulator
+
+    All flow simulators will have the interface of this class and
+    should be derived from this class.
+    """
+
+    def __init__(
+        self,
+        grid_dim: int,
+        # TODO fix mypy error and enable type hint
+        grid_size,  # : tuple[int, int] | tuple[int, int, int],
+        x_range: float,
+        real_t: Type = np.float32,
+        num_threads: int = 1,
+        time: float = 0.0,
+    ) -> None:
+        """Class initialiser
+
+        :param grid_dim: grid dimensions
+        :param grid_size: Grid size of simulator
+        :param x_range: Range of X coordinate of the grid
+        :param real_t: precision of the solver
+        :param num_threads: number of threads
+        :param time: simulator time at initialisation
+
+        """
+        if grid_dim not in [2, 3]:
+            raise ValueError(
+                "Invalid grid dimensions. Supported values include 2 and 3."
+            )
+        self.grid_dim = grid_dim
+        self.grid_size = grid_size
+        self.x_range = x_range
+        self.real_t = real_t
+        self.num_threads = num_threads
+        self.time = time
+        self._init_domain()
+        self._init_fields()
+        self._compile_kernels()
+        self._finalise_flow_time_step()
+
+    def _init_domain(self) -> None:
+        """Initialize the domain i.e. grid coordinates. etc."""
+        grid_size_x = self.grid_size[-1]
+        self.dx = self.real_t(self.x_range / grid_size_x)
+        eul_grid_shift = self.dx / 2.0
+        x = np.linspace(
+            eul_grid_shift, self.x_range - eul_grid_shift, grid_size_x
+        ).astype(self.real_t)
+        match self.grid_dim:
+            case 2:
+                grid_size_y, grid_size_x = self.grid_size
+                self.y_range = self.x_range * grid_size_y / grid_size_x
+                y = np.linspace(
+                    eul_grid_shift, self.y_range - eul_grid_shift, grid_size_y
+                ).astype(self.real_t)
+                # reversing because meshgrid generates in order Y and X
+                self.position_field = np.flipud(
+                    np.array(np.meshgrid(y, x, indexing="ij"))
+                )
+            case 3:
+                grid_size_z, grid_size_y, grid_size_x = self.grid_size
+                self.y_range = self.x_range * grid_size_y / grid_size_x
+                self.z_range = self.x_range * grid_size_z / grid_size_x
+                y = np.linspace(
+                    eul_grid_shift, self.y_range - eul_grid_shift, grid_size_y
+                ).astype(self.real_t)
+                z = np.linspace(
+                    eul_grid_shift, self.z_range - eul_grid_shift, grid_size_z
+                ).astype(self.real_t)
+                # reversing because meshgrid generates in order Z, Y and X
+                self.position_field = np.flipud(
+                    np.array(np.meshgrid(z, y, x, indexing="ij"))
+                )
+        log = logging.getLogger()
+        log.warning(
+            "==============================================="
+            f"\n{self.grid_dim}D flow domain initialized with:"
+            f"\nX axis from 0.0 to {self.x_range}"
+        )
+        match self.grid_dim:
+            case 2:
+                log.warning(f"\nY axis from 0.0 to {self.y_range}")
+            case 3:
+                log.warning(
+                    f"\nY axis from 0.0 to {self.y_range}"
+                    f"\nZ axis from 0.0 to {self.z_range}"
+                )
+        log.warning(
+            "\nPlease initialize bodies within these bounds!"
+            "\n==============================================="
+        )
+
+    def _init_fields(self) -> None:
+        """Initialize the necessary field arrays"""
+        ...
+
+    def _compile_kernels(self) -> None:
+        """Compile necessary kernels based on flow type"""
+        ...
+
+    def _flow_time_step(self, dt: float, **kwargs):
+        """Flow time step, stepping through the algorithm"""
+        ...
+
+    def _finalise_flow_time_step(self) -> None:
+        """Finalise the flow time step
+
+        This function will set the member function 'flow_time_step'
+        based on the type and the flags inside the simulator.
+        """
+        ...
+
+    def compute_stable_time_step(self) -> float:
+        """Compute upper limit for stable time-stepping."""
+        ...
+
+    def _update_simulator_time(self, dt: float) -> None:
+        """Updates simulator time."""
+        self.time += dt
+
+    def time_step(self, dt: float, **kwargs) -> None:
+        """Final simulator time step"""
+        self._flow_time_step(dt=dt, **kwargs)
+        self._update_simulator_time(dt=dt)

--- a/sopht/simulator/flow/flow_simulators.py
+++ b/sopht/simulator/flow/flow_simulators.py
@@ -1,6 +1,7 @@
 import logging
 import numpy as np
 from typing import Type
+from abc import abstractmethod
 
 
 class FlowSimulator:
@@ -97,18 +98,22 @@ class FlowSimulator:
             "\n==============================================="
         )
 
+    @abstractmethod
     def _init_fields(self) -> None:
         """Initialize the necessary field arrays"""
         ...
 
+    @abstractmethod
     def _compile_kernels(self) -> None:
         """Compile necessary kernels based on flow type"""
         ...
 
+    @abstractmethod
     def _flow_time_step(self, dt: float, **kwargs):
         """Flow time step, stepping through the algorithm"""
         ...
 
+    @abstractmethod
     def _finalise_flow_time_step(self) -> None:
         """Finalise the flow time step
 
@@ -117,6 +122,7 @@ class FlowSimulator:
         """
         ...
 
+    @abstractmethod
     def compute_stable_timestep(self) -> float:
         """Compute upper limit for stable time-stepping."""
         ...

--- a/sopht/simulator/flow/flow_simulators.py
+++ b/sopht/simulator/flow/flow_simulators.py
@@ -86,14 +86,14 @@ class FlowSimulator:
         )
         match self.grid_dim:
             case 2:
-                log.warning(f"\nY axis from 0.0 to {self.y_range}")
+                log.warning(f"Y axis from 0.0 to {self.y_range}")
             case 3:
                 log.warning(
-                    f"\nY axis from 0.0 to {self.y_range}"
+                    f"Y axis from 0.0 to {self.y_range}"
                     f"\nZ axis from 0.0 to {self.z_range}"
                 )
         log.warning(
-            "\nPlease initialize bodies within these bounds!"
+            "Please initialize bodies within these bounds!"
             "\n==============================================="
         )
 
@@ -117,7 +117,7 @@ class FlowSimulator:
         """
         ...
 
-    def compute_stable_time_step(self) -> float:
+    def compute_stable_timestep(self) -> float:
         """Compute upper limit for stable time-stepping."""
         ...
 

--- a/sopht/simulator/flow/flow_simulators_2d.py
+++ b/sopht/simulator/flow/flow_simulators_2d.py
@@ -1,270 +1,53 @@
-import logging
 import numpy as np
-import sopht.numeric.eulerian_grid_ops as spne
-import sopht.utils as spu
-from typing import Callable, Literal
+from typing import Literal
+from .navier_stokes_flow_simulators import UnboundedNavierStokesFlowSimulator2D
 
 
-class UnboundedFlowSimulator2D:
-    """Class for 2D unbounded flow simulator"""
+def UnboundedFlowSimulator2D(
+    grid_size: tuple[int, int],
+    x_range: float,
+    kinematic_viscosity: float,
+    CFL: float = 0.1,
+    flow_type: Literal["navier_stokes", "navier_stokes_with_forcing"] = "navier_stokes",
+    real_t: type = np.float32,
+    num_threads: int = 1,
+    time: float = 0.0,
+    **kwargs,
+) -> UnboundedNavierStokesFlowSimulator2D:
+    """Function forwarding 2D unbounded Navier Stokes flow simulator.
 
-    def __init__(
-        self,
-        grid_size: tuple[int, int],
-        x_range: float,
-        kinematic_viscosity: float,
-        CFL: float = 0.1,
-        flow_type: Literal[
-            "passive_scalar", "navier_stokes", "navier_stokes_with_forcing"
-        ] = "passive_scalar",
-        real_t: type = np.float32,
-        num_threads: int = 1,
-        time: float = 0.0,
-        **kwargs,
-    ) -> None:
-        """Class initialiser
+    :param grid_size: Grid size of simulator
+    :param x_range: Range of X coordinate of the grid
+    :param kinematic_viscosity: kinematic viscosity of the fluid
+    :param CFL: Courant Freidrich Lewy number (advection timestep)
+    :param flow_type: Nature of the simulator, can be "passive_scalar" (default value),
+    "navier_stokes" or "navier_stokes_with_forcing"
+    :param real_t: precision of the solver
+    :param num_threads: number of threads
+    :param time: simulator time at initialisation
 
-        :param grid_size: Grid size of simulator
-        :param x_range: Range of X coordinate of the grid
-        :param kinematic_viscosity: kinematic viscosity of the fluid
-        :param CFL: Courant Freidrich Lewy number (advection timestep)
-        :param flow_type: Nature of the simulator, can be "passive_scalar" (default value),
-        "navier_stokes" or "navier_stokes_with_forcing"
-        :param real_t: precision of the solver
-        :param num_threads: number of threads
-        :param time: simulator time at initialisation
-
-        Notes
-        -----
-        Currently only supports Euler forward timesteps :(
-        """
-        self.grid_dim = 2
-        self.grid_size = grid_size
-        self.x_range = x_range
-        self.real_t = real_t
-        self.num_threads = num_threads
-        self.flow_type = flow_type
-        self.kinematic_viscosity = kinematic_viscosity
-        self.CFL = CFL
-        self.time = time
-        supported_flow_types = [
-            "passive_scalar",
-            "navier_stokes",
-            "navier_stokes_with_forcing",
-        ]
-        if self.flow_type not in supported_flow_types:
+    Notes
+    -----
+    This function exists for backward compatability.
+    Currently, only supports Euler forward timesteps :(
+    """
+    match flow_type:
+        case "navier_stokes":
+            with_forcing = False
+        case "navier_stokes_with_forcing":
+            with_forcing = True
+        case _:
             raise ValueError("Invalid flow type given")
-        self._init_domain()
-        self._init_fields()
-        if self.flow_type in ["navier_stokes", "navier_stokes_with_forcing"]:
-            self.with_free_stream_flow = kwargs.get("with_free_stream_flow", False)
-            self.penalty_zone_width = kwargs.get("penalty_zone_width", 2)
-        self._compile_kernels()
-        self._finalise_flow_timestep()
 
-    def _init_domain(self) -> None:
-        """Initialize the domain i.e. grid coordinates. etc."""
-        grid_size_y, grid_size_x = self.grid_size
-        self.y_range = self.x_range * grid_size_y / grid_size_x
-        self.dx = self.real_t(self.x_range / grid_size_x)
-        eul_grid_shift = self.dx / 2.0
-        x: np.ndarray = np.linspace(
-            eul_grid_shift, self.x_range - eul_grid_shift, grid_size_x
-        ).astype(self.real_t)
-        y: np.ndarray = np.linspace(
-            eul_grid_shift, self.y_range - eul_grid_shift, grid_size_y
-        ).astype(self.real_t)
-        # reversing because meshgrid generates in order Y and X
-        self.position_field = np.flipud(np.array(np.meshgrid(y, x, indexing="ij")))
-        log = logging.getLogger()
-        log.warning(
-            "==============================================="
-            f"\n{self.grid_dim}D flow domain initialized with:"
-            f"\nX axis from 0.0 to {self.x_range}"
-            f"\nY axis from 0.0 to {self.y_range}"
-            "\nPlease initialize bodies within these bounds!"
-            "\n==============================================="
-        )
-
-    def _init_fields(self) -> None:
-        """Initialize the necessary field arrays, i.e. vorticity, velocity, etc."""
-        # Initialize flow field
-        self.primary_scalar_field: np.ndarray = np.zeros(
-            self.grid_size, dtype=self.real_t
-        )
-        self.velocity_field: np.ndarray = np.zeros(
-            (self.grid_dim, *self.grid_size), dtype=self.real_t
-        )
-        # we use the same buffer for advection, diffusion and velocity recovery
-        self.buffer_scalar_field = np.zeros_like(self.primary_scalar_field)
-
-        if self.flow_type in ["navier_stokes", "navier_stokes_with_forcing"]:
-            self.vorticity_field = self.primary_scalar_field.view()
-            self.stream_func_field = np.zeros_like(self.vorticity_field)
-        if self.flow_type == "navier_stokes_with_forcing":
-            # this one holds the forcing from bodies
-            self.eul_grid_forcing_field = np.zeros_like(self.velocity_field)
-
-    def _compile_kernels(self) -> None:
-        """Compile necessary kernels based on flow type"""
-        self.diffusion_timestep = (
-            spne.gen_diffusion_timestep_euler_forward_pyst_kernel_2d(
-                real_t=self.real_t,
-                fixed_grid_size=self.grid_size,
-                num_threads=self.num_threads,
-            )
-        )
-        self.advection_timestep = (
-            spne.gen_advection_timestep_euler_forward_conservative_eno3_pyst_kernel_2d(
-                real_t=self.real_t,
-                fixed_grid_size=self.grid_size,
-                num_threads=self.num_threads,
-            )
-        )
-
-        if self.flow_type in ["navier_stokes", "navier_stokes_with_forcing"]:
-            grid_size_y, grid_size_x = self.grid_size
-            self.unbounded_poisson_solver = spne.UnboundedPoissonSolverPYFFTW2D(
-                grid_size_y=grid_size_y,
-                grid_size_x=grid_size_x,
-                x_range=self.x_range,
-                real_t=self.real_t,
-                num_threads=self.num_threads,
-            )
-            self.curl = spne.gen_outplane_field_curl_pyst_kernel_2d(
-                real_t=self.real_t,
-                num_threads=self.num_threads,
-                fixed_grid_size=self.grid_size,
-            )
-            self.penalise_field_towards_boundary = (
-                spne.gen_penalise_field_boundary_pyst_kernel_2d(
-                    width=self.penalty_zone_width,
-                    dx=self.dx,
-                    x_grid_field=self.position_field[spu.VectorField.x_axis_idx()],
-                    y_grid_field=self.position_field[spu.VectorField.y_axis_idx()],
-                    real_t=self.real_t,
-                    num_threads=self.num_threads,
-                    fixed_grid_size=self.grid_size,
-                )
-            )
-
-        if self.flow_type == "navier_stokes_with_forcing":
-            self.update_vorticity_from_velocity_forcing = (
-                spne.gen_update_vorticity_from_velocity_forcing_pyst_kernel_2d(
-                    real_t=self.real_t,
-                    fixed_grid_size=self.grid_size,
-                    num_threads=self.num_threads,
-                )
-            )
-            self.set_field = spne.gen_set_fixed_val_pyst_kernel_2d(
-                real_t=self.real_t,
-                num_threads=self.num_threads,
-                field_type="vector",
-            )
-        # free stream velocity stuff (only meaningful in navier stokes problems)
-        if self.flow_type in ["navier_stokes", "navier_stokes_with_forcing"]:
-            if self.with_free_stream_flow:
-                add_fixed_val = spne.gen_add_fixed_val_pyst_kernel_2d(
-                    real_t=self.real_t,
-                    fixed_grid_size=self.grid_size,
-                    num_threads=self.num_threads,
-                    field_type="vector",
-                )
-
-                def update_velocity_with_free_stream(
-                    free_stream_velocity: np.ndarray,
-                ) -> None:
-                    add_fixed_val(
-                        sum_field=self.velocity_field,
-                        vector_field=self.velocity_field,
-                        fixed_vals=free_stream_velocity,
-                    )
-
-            else:
-
-                def update_velocity_with_free_stream(
-                    free_stream_velocity: np.ndarray,
-                ) -> None:
-                    ...
-
-            self.update_velocity_with_free_stream = update_velocity_with_free_stream
-
-    def _finalise_flow_timestep(self) -> None:
-        self.flow_time_step: Callable
-        # defqult time step
-        self.flow_time_step = self.advection_and_diffusion_timestep
-        if self.flow_type == "navier_stokes":
-            self.flow_time_step = self.navier_stokes_timestep
-        elif self.flow_type == "navier_stokes_with_forcing":
-            self.flow_time_step = self.navier_stokes_with_forcing_timestep
-
-    def update_simulator_time(self, dt: float) -> None:
-        """Updates simulator time."""
-        self.time += dt
-
-    def time_step(self, dt: float, **kwargs) -> None:
-        """Final simulator time step"""
-        self.flow_time_step(dt=dt, **kwargs)
-        self.update_simulator_time(dt=dt)
-
-    def advection_and_diffusion_timestep(self, dt: float, **kwargs) -> None:
-        self.advection_timestep(
-            field=self.primary_scalar_field,
-            advection_flux=self.buffer_scalar_field,
-            velocity=self.velocity_field,
-            dt_by_dx=self.real_t(dt / self.dx),
-        )
-        self.diffusion_timestep(
-            field=self.primary_scalar_field,
-            diffusion_flux=self.buffer_scalar_field,
-            nu_dt_by_dx2=self.real_t(self.kinematic_viscosity * dt / self.dx / self.dx),
-        )
-
-    def compute_velocity_from_vorticity(
-        self,
-    ) -> None:
-        self.penalise_field_towards_boundary(field=self.vorticity_field)
-        self.unbounded_poisson_solver.solve(
-            solution_field=self.stream_func_field,
-            rhs_field=self.vorticity_field,
-        )
-        self.curl(
-            curl=self.velocity_field,
-            field=self.stream_func_field,
-            prefactor=self.real_t(0.5 / self.dx),
-        )
-
-    def navier_stokes_timestep(
-        self, dt: float, free_stream_velocity: np.ndarray = np.zeros(2)
-    ):
-        self.advection_and_diffusion_timestep(dt=dt)
-        self.compute_velocity_from_vorticity()
-        self.update_velocity_with_free_stream(free_stream_velocity=free_stream_velocity)
-
-    def navier_stokes_with_forcing_timestep(
-        self, dt: float, free_stream_velocity: np.ndarray = np.zeros(2)
-    ) -> None:
-        self.update_vorticity_from_velocity_forcing(
-            vorticity_field=self.vorticity_field,
-            velocity_forcing_field=self.eul_grid_forcing_field,
-            prefactor=self.real_t(dt / (2 * self.dx)),
-        )
-        self.navier_stokes_timestep(dt=dt, free_stream_velocity=free_stream_velocity)
-        self.set_field(
-            vector_field=self.eul_grid_forcing_field, fixed_vals=[0.0] * self.grid_dim
-        )
-
-    def compute_stable_timestep(
-        self, dt_prefac: float = 1, precision: str = "single"
-    ) -> float:
-        """Compute stable timestep based on advection and diffusion limits."""
-        # This may need a numba or pystencil version
-        velocity_mag_field = self.buffer_scalar_field.view()
-        velocity_mag_field[...] = np.sum(np.fabs(self.velocity_field), axis=0)
-        dt = min(
-            self.CFL
-            * self.dx
-            / (np.amax(velocity_mag_field) + spu.get_test_tol(precision)),
-            0.9 * self.dx**2 / (2 * self.grid_dim) / self.kinematic_viscosity,
-        )
-        return dt * dt_prefac
+    flow_simulator = UnboundedNavierStokesFlowSimulator2D(
+        grid_size=grid_size,
+        x_range=x_range,
+        kinematic_viscosity=kinematic_viscosity,
+        cfl=CFL,
+        real_t=real_t,
+        num_threads=num_threads,
+        time=time,
+        with_forcing=with_forcing,
+        **kwargs,
+    )
+    return flow_simulator

--- a/sopht/simulator/flow/flow_simulators_3d.py
+++ b/sopht/simulator/flow/flow_simulators_3d.py
@@ -1,448 +1,63 @@
-import logging
 import numpy as np
-import sopht.numeric.eulerian_grid_ops as spne
-import sopht.utils as spu
-from typing import Type, Callable, Literal
+from typing import Literal
+from .navier_stokes_flow_simulators import UnboundedNavierStokesFlowSimulator3D
 
 
-# TODO refactor 2D and 3D with a common base simulator class
-class UnboundedFlowSimulator3D:
-    """Class for 3D unbounded flow simulator"""
+def UnboundedFlowSimulator3D(
+    grid_size: tuple[int, int, int],
+    x_range: float,
+    kinematic_viscosity: float,
+    CFL: float = 0.1,
+    flow_type: Literal["navier_stokes", "navier_stokes_with_forcing"] = "navier_stokes",
+    real_t: type = np.float32,
+    num_threads: int = 1,
+    filter_vorticity: bool = False,
+    poisson_solver_type: Literal[
+        "greens_function_convolution", "fast_diagonalisation"
+    ] = "greens_function_convolution",
+    time: float = 0.0,
+    **kwargs,
+) -> UnboundedNavierStokesFlowSimulator3D:
+    """Function forwarding 3D unbounded Navier Stokes flow simulator.
 
-    def __init__(
-        self,
-        grid_size: tuple[int, int, int],
-        x_range: float,
-        kinematic_viscosity: float,
-        CFL: float = 0.1,
-        flow_type: Literal[
-            "passive_scalar",
-            "passive_vector",
-            "navier_stokes",
-            "navier_stokes_with_forcing",
-        ] = "passive_scalar",
-        real_t: Type = np.float32,
-        num_threads: int = 1,
-        filter_vorticity: bool = False,
-        poisson_solver_type: Literal[
-            "greens_function_convolution", "fast_diagonalisation"
-        ] = "greens_function_convolution",
-        time: float = 0.0,
-        **kwargs,
-    ) -> None:
-        """Class initialiser
+    :param grid_size: Grid size of simulator
+    :param x_range: Range of X coordinate of the grid
+    :param kinematic_viscosity: kinematic viscosity of the fluid
+    :param CFL: Courant Freidrich Lewy number (advection timestep)
+    :param flow_type: Nature of the simulator, can be "passive_scalar" (default value),
+    "navier_stokes" or "navier_stokes_with_forcing"
+    :param real_t: precision of the solver
+    :param num_threads: number of threads
+    :param filter_vorticity: flag to determine if vorticity should be filtered or not,
+    needed for stability sometimes
+    :param poisson_solver_type: Type of the poisson solver algorithm, can be
+    "greens_function_convolution" or "fast_diagonalisation"
+    :param time: simulator time at initialisation
 
-        :param grid_size: Grid size of simulator
-        :param x_range: Range of X coordinate of the grid
-        :param kinematic_viscosity: kinematic viscosity of the fluid
-        :param CFL: Courant Freidrich Lewy number (advection timestep)
-        :param flow_type: Nature of the simulator, can be "passive_scalar" (default value),
-        "passive_vector", "navier_stokes" or "navier_stokes_with_forcing"
-        :param real_t: precision of the solver
-        :param num_threads: number of threads
-        :param filter_vorticity: flag to determine if vorticity should be filtered or not,
-        needed for stability sometimes
-        :param poisson_solver_type: Type of the poisson solver algorithm, can be
-        "greens_function_convolution" or "fast_diagonalisation"
-        :param time: simulator time at initialisation
-
-        Notes
-        -----
-        Currently only supports Euler forward timesteps :(
-        """
-        self.grid_dim = 3
-        self.grid_size = grid_size
-        self.x_range = x_range
-        self.real_t = real_t
-        self.num_threads = num_threads
-        self.flow_type = flow_type
-        self.kinematic_viscosity = kinematic_viscosity
-        self.CFL = CFL
-        self.time = time
-        self.filter_vorticity = filter_vorticity
-        self.poisson_solver_type = poisson_solver_type
-        supported_flow_types = [
-            "passive_scalar",
-            "passive_vector",
-            "navier_stokes",
-            "navier_stokes_with_forcing",
-        ]
-        if self.flow_type not in supported_flow_types:
+    Notes
+    -----
+    This function exists for backward compatability.
+    Currently, only supports Euler forward timesteps :(
+    """
+    match flow_type:
+        case "navier_stokes":
+            with_forcing = False
+        case "navier_stokes_with_forcing":
+            with_forcing = True
+        case _:
             raise ValueError("Invalid flow type given")
-        self._init_domain()
-        self._init_fields()
-        if self.flow_type in ["navier_stokes", "navier_stokes_with_forcing"]:
-            self.penalty_zone_width = kwargs.get("penalty_zone_width", 2)
-            self.with_free_stream_flow = kwargs.get("with_free_stream_flow", False)
-            if self.filter_vorticity:
-                log = logging.getLogger()
-                log.warning(
-                    "==============================================="
-                    "\nVorticity filtering is turned on."
-                )
-                # default values for the filter setting dictionary
-                default_filter_setting_dict: dict[
-                    str, int | Literal["multiplicative", "convolution"]
-                ] = {"order": 2, "type": "multiplicative"}
-                self.filter_setting_dict = kwargs.get(
-                    "filter_setting_dict", default_filter_setting_dict
-                )
-                log.warning(
-                    f"Setting default filter order = {self.filter_setting_dict['order']}"
-                    f"\nand type = {self.filter_setting_dict['type']}. For custom filtering,"
-                    "\nprovide a dictionary called 'filter_setting_dict'"
-                    "\nwith keys 'order' and 'type'."
-                )
-                log.warning("===============================================")
-            # check validity of poisson solver types
-            supported_poisson_solver_types = [
-                "greens_function_convolution",
-                "fast_diagonalisation",
-            ]
-            if self.poisson_solver_type not in supported_poisson_solver_types:
-                raise ValueError("Invalid Poisson solver type given")
-        self._compile_kernels()
-        self._finalise_flow_timestep()
 
-    def _init_domain(self) -> None:
-        """Initialize the domain i.e. grid coordinates. etc."""
-        grid_size_z, grid_size_y, grid_size_x = self.grid_size
-        self.y_range = self.x_range * grid_size_y / grid_size_x
-        self.z_range = self.x_range * grid_size_z / grid_size_x
-        self.dx = self.real_t(self.x_range / grid_size_x)
-        eul_grid_shift = self.dx / 2.0
-        x = np.linspace(
-            eul_grid_shift, self.x_range - eul_grid_shift, grid_size_x
-        ).astype(self.real_t)
-        y = np.linspace(
-            eul_grid_shift, self.y_range - eul_grid_shift, grid_size_y
-        ).astype(self.real_t)
-        z = np.linspace(
-            eul_grid_shift, self.z_range - eul_grid_shift, grid_size_z
-        ).astype(self.real_t)
-        # reversing because meshgrid generates in order Z, Y and X
-        self.position_field = np.flipud(np.array(np.meshgrid(z, y, x, indexing="ij")))
-        log = logging.getLogger()
-        log.warning(
-            "==============================================="
-            f"\n{self.grid_dim}D flow domain initialized with:"
-            f"\nX axis from 0.0 to {self.x_range}"
-            f"\nY axis from 0.0 to {self.y_range}"
-            f"\nZ axis from 0.0 to {self.z_range}"
-            "\nPlease initialize bodies within these bounds!"
-            "\n==============================================="
-        )
-
-    def _init_fields(self) -> None:
-        """Initialize the necessary field arrays, i.e. vorticity, velocity, etc."""
-        # Initialize flow field
-        self.primary_scalar_field = np.zeros(self.grid_size, dtype=self.real_t)
-        self.velocity_field = np.zeros(
-            (self.grid_dim, *self.grid_size), dtype=self.real_t
-        )
-        # we use the same buffer for advection, diffusion, stretching
-        # and velocity recovery
-        self.buffer_scalar_field = np.zeros_like(self.primary_scalar_field)
-
-        if self.flow_type in [
-            "passive_vector",
-            "navier_stokes",
-            "navier_stokes_with_forcing",
-        ]:
-            self.primary_vector_field = np.zeros_like(self.velocity_field)
-            del self.primary_scalar_field  # not needed
-
-        if self.flow_type in ["navier_stokes", "navier_stokes_with_forcing"]:
-            self.vorticity_field = self.primary_vector_field.view()
-            self.stream_func_field = np.zeros_like(self.vorticity_field)
-            self.buffer_vector_field = np.zeros_like(self.vorticity_field)
-        if self.flow_type == "navier_stokes_with_forcing":
-            # this one holds the forcing from bodies
-            self.eul_grid_forcing_field = np.zeros_like(self.velocity_field)
-
-    def _compile_kernels(self) -> None:
-        """Compile necessary kernels based on flow type"""
-        if self.flow_type == "passive_scalar":
-            self.diffusion_timestep = (
-                spne.gen_diffusion_timestep_euler_forward_pyst_kernel_3d(
-                    real_t=self.real_t,
-                    fixed_grid_size=self.grid_size,
-                    num_threads=self.num_threads,
-                    field_type="scalar",
-                )
-            )
-            self.advection_timestep = spne.gen_advection_timestep_euler_forward_conservative_eno3_pyst_kernel_3d(
-                real_t=self.real_t,
-                fixed_grid_size=self.grid_size,
-                num_threads=self.num_threads,
-                field_type="scalar",
-            )
-        elif self.flow_type == "passive_vector":
-            self.diffusion_timestep = (
-                spne.gen_diffusion_timestep_euler_forward_pyst_kernel_3d(
-                    real_t=self.real_t,
-                    fixed_grid_size=self.grid_size,
-                    num_threads=self.num_threads,
-                    field_type="vector",
-                )
-            )
-            self.advection_timestep = spne.gen_advection_timestep_euler_forward_conservative_eno3_pyst_kernel_3d(
-                real_t=self.real_t,
-                fixed_grid_size=self.grid_size,
-                num_threads=self.num_threads,
-                field_type="vector",
-            )
-
-        if self.flow_type in ["navier_stokes", "navier_stokes_with_forcing"]:
-            self.diffusion_timestep = (
-                spne.gen_diffusion_timestep_euler_forward_pyst_kernel_3d(
-                    real_t=self.real_t,
-                    fixed_grid_size=self.grid_size,
-                    num_threads=self.num_threads,
-                    field_type="vector",
-                )
-            )
-            grid_size_z, grid_size_y, grid_size_x = self.grid_size
-            self.unbounded_poisson_solver: spne.UnboundedPoissonSolverPYFFTW3D | spne.FastDiagPoissonSolver3D
-            if self.poisson_solver_type == "greens_function_convolution":
-                self.unbounded_poisson_solver = spne.UnboundedPoissonSolverPYFFTW3D(
-                    grid_size_z=grid_size_z,
-                    grid_size_y=grid_size_y,
-                    grid_size_x=grid_size_x,
-                    x_range=self.x_range,
-                    real_t=self.real_t,
-                    num_threads=self.num_threads,
-                )
-            elif self.poisson_solver_type == "fast_diagonalisation":
-                self.unbounded_poisson_solver = spne.FastDiagPoissonSolver3D(
-                    grid_size_z=grid_size_z,
-                    grid_size_y=grid_size_y,
-                    grid_size_x=grid_size_x,
-                    dx=self.dx,
-                    real_t=self.real_t,
-                    # TODO add different options here later
-                    bc_type="homogenous_neumann_along_xyz",
-                )
-            self.curl = spne.gen_curl_pyst_kernel_3d(
-                real_t=self.real_t,
-                num_threads=self.num_threads,
-                fixed_grid_size=self.grid_size,
-            )
-            self.penalise_field_towards_boundary = (
-                spne.gen_penalise_field_boundary_pyst_kernel_3d(
-                    width=self.penalty_zone_width,
-                    dx=self.dx,
-                    x_grid_field=self.position_field[spu.VectorField.x_axis_idx()],
-                    y_grid_field=self.position_field[spu.VectorField.y_axis_idx()],
-                    z_grid_field=self.position_field[spu.VectorField.z_axis_idx()],
-                    real_t=self.real_t,
-                    num_threads=self.num_threads,
-                    fixed_grid_size=self.grid_size,
-                    field_type="vector",
-                )
-            )
-            self.elementwise_cross_product = (
-                spne.gen_elementwise_cross_product_pyst_kernel_3d(
-                    real_t=self.real_t,
-                    num_threads=self.num_threads,
-                    fixed_grid_size=self.grid_size,
-                )
-            )
-            self.update_vorticity_from_velocity_forcing = (
-                spne.gen_update_vorticity_from_velocity_forcing_pyst_kernel_3d(
-                    real_t=self.real_t,
-                    fixed_grid_size=self.grid_size,
-                    num_threads=self.num_threads,
-                )
-            )
-            # check if vorticity stays divergence free
-            self.compute_divergence = spne.gen_divergence_pyst_kernel_3d(
-                real_t=self.real_t,
-                fixed_grid_size=self.grid_size,
-                num_threads=self.num_threads,
-            )
-
-            # filter kernel compilation
-            def filter_vector_field(vector_field: np.ndarray) -> None:
-                ...
-
-            self.filter_vector_field = filter_vector_field
-            if self.filter_vorticity and self.filter_setting_dict is not None:
-                self.filter_vector_field = spne.gen_laplacian_filter_kernel_3d(
-                    filter_order=self.filter_setting_dict["order"],
-                    filter_flux_buffer=self.buffer_vector_field[0],
-                    field_buffer=self.buffer_vector_field[1],
-                    real_t=self.real_t,
-                    num_threads=self.num_threads,
-                    fixed_grid_size=self.grid_size,
-                    field_type="vector",
-                    filter_type=self.filter_setting_dict["type"],
-                )
-
-        if self.flow_type == "navier_stokes_with_forcing":
-            self.set_field = spne.gen_set_fixed_val_pyst_kernel_3d(
-                real_t=self.real_t,
-                num_threads=self.num_threads,
-                field_type="vector",
-            )
-        # free stream velocity stuff (only meaningful in navier stokes problems)
-        if self.flow_type in ["navier_stokes", "navier_stokes_with_forcing"]:
-            if self.with_free_stream_flow:
-                add_fixed_val = spne.gen_add_fixed_val_pyst_kernel_3d(
-                    real_t=self.real_t,
-                    fixed_grid_size=self.grid_size,
-                    num_threads=self.num_threads,
-                    field_type="vector",
-                )
-
-                def update_velocity_with_free_stream(
-                    free_stream_velocity: np.ndarray,
-                ) -> None:
-                    add_fixed_val(
-                        sum_field=self.velocity_field,
-                        vector_field=self.velocity_field,
-                        fixed_vals=free_stream_velocity,
-                    )
-
-            else:
-
-                def update_velocity_with_free_stream(
-                    free_stream_velocity: np.ndarray,
-                ) -> None:
-                    ...
-
-            self.update_velocity_with_free_stream = update_velocity_with_free_stream
-
-    def _finalise_navier_stokes_timestep(self) -> None:
-        def default_navier_stokes_timestep(
-            dt: float, free_stream_velocity: np.ndarray
-        ) -> None:
-            ...
-
-        self.navier_stokes_timestep = default_navier_stokes_timestep
-        if self.flow_type in ["navier_stokes", "navier_stokes_with_forcing"]:
-            self.navier_stokes_timestep = self.rotational_form_navier_stokes_timestep
-
-    def _finalise_flow_timestep(self) -> None:
-        self._finalise_navier_stokes_timestep()
-        self.flow_time_step: Callable
-        # defqult time step
-        self.flow_time_step = self.scalar_advection_and_diffusion_timestep
-        if self.flow_type == "passive_vector":
-            self.flow_time_step = self.vector_advection_and_diffusion_timestep
-        elif self.flow_type == "navier_stokes":
-            self.flow_time_step = self.navier_stokes_timestep
-        elif self.flow_type == "navier_stokes_with_forcing":
-            self.flow_time_step = self.navier_stokes_with_forcing_timestep
-
-    def update_simulator_time(self, dt: float) -> None:
-        """Updates simulator time."""
-        self.time += dt
-
-    def time_step(self, dt: float, **kwargs) -> None:
-        """Final simulator time step"""
-        self.flow_time_step(dt=dt, **kwargs)
-        self.update_simulator_time(dt=dt)
-
-    def scalar_advection_and_diffusion_timestep(self, dt: float, **kwargs) -> None:
-        self.advection_timestep(
-            field=self.primary_scalar_field,
-            advection_flux=self.buffer_scalar_field,
-            velocity=self.velocity_field,
-            dt_by_dx=self.real_t(dt / self.dx),
-        )
-        self.diffusion_timestep(
-            field=self.primary_scalar_field,
-            diffusion_flux=self.buffer_scalar_field,
-            nu_dt_by_dx2=self.real_t(self.kinematic_viscosity * dt / self.dx / self.dx),
-        )
-
-    def vector_advection_and_diffusion_timestep(self, dt: float, **kwargs) -> None:
-        self.advection_timestep(
-            vector_field=self.primary_vector_field,
-            advection_flux=self.buffer_scalar_field,
-            velocity=self.velocity_field,
-            dt_by_dx=self.real_t(dt / self.dx),
-        )
-        self.diffusion_timestep(
-            vector_field=self.primary_vector_field,
-            diffusion_flux=self.buffer_scalar_field,
-            nu_dt_by_dx2=self.real_t(self.kinematic_viscosity * dt / self.dx / self.dx),
-        )
-
-    def compute_flow_velocity(self, free_stream_velocity: np.ndarray) -> None:
-        self.penalise_field_towards_boundary(vector_field=self.vorticity_field)
-        self.unbounded_poisson_solver.vector_field_solve(
-            solution_vector_field=self.stream_func_field,
-            rhs_vector_field=self.vorticity_field,
-        )
-        self.curl(
-            curl=self.velocity_field,
-            field=self.stream_func_field,
-            prefactor=self.real_t(0.5 / self.dx),
-        )
-        self.update_velocity_with_free_stream(free_stream_velocity=free_stream_velocity)
-
-    def rotational_form_navier_stokes_timestep(
-        self,
-        dt: float,
-        free_stream_velocity: np.ndarray = np.zeros(3),
-    ) -> None:
-        velocity_cross_vorticity = self.buffer_vector_field.view()
-        self.elementwise_cross_product(
-            result_field=velocity_cross_vorticity,
-            field_1=self.velocity_field,
-            field_2=self.vorticity_field,
-        )
-        self.update_vorticity_from_velocity_forcing(
-            vorticity_field=self.vorticity_field,
-            velocity_forcing_field=velocity_cross_vorticity,
-            prefactor=self.real_t(dt / (2 * self.dx)),
-        )
-        self.diffusion_timestep(
-            vector_field=self.vorticity_field,
-            diffusion_flux=self.buffer_scalar_field,
-            nu_dt_by_dx2=self.real_t(self.kinematic_viscosity * dt / self.dx / self.dx),
-        )
-        self.filter_vector_field(vector_field=self.vorticity_field)
-        self.compute_flow_velocity(free_stream_velocity=free_stream_velocity)
-
-    def navier_stokes_with_forcing_timestep(
-        self,
-        dt: float,
-        free_stream_velocity: np.ndarray = np.zeros(3),
-    ) -> None:
-        self.update_vorticity_from_velocity_forcing(
-            vorticity_field=self.vorticity_field,
-            velocity_forcing_field=self.eul_grid_forcing_field,
-            prefactor=self.real_t(dt / (2 * self.dx)),
-        )
-        self.navier_stokes_timestep(dt=dt, free_stream_velocity=free_stream_velocity)
-        self.set_field(
-            vector_field=self.eul_grid_forcing_field, fixed_vals=[0.0] * self.grid_dim
-        )
-
-    def compute_stable_timestep(
-        self, dt_prefac: float = 1, precision: str = "single"
-    ) -> float:
-        """Compute stable timestep based on advection and diffusion limits."""
-        # This may need a numba or pystencil version
-        velocity_mag_field = self.buffer_scalar_field.view()
-        tol = spu.get_test_tol(precision)
-        velocity_mag_field[...] = np.sum(np.fabs(self.velocity_field), axis=0)
-        dt = min(
-            self.CFL * self.dx / (np.amax(velocity_mag_field) + tol),
-            0.9 * self.dx**2 / (2 * self.grid_dim) / (self.kinematic_viscosity + tol),
-        )
-        return dt * dt_prefac
-
-    def get_vorticity_divergence_l2_norm(self) -> float:
-        """Return L2 norm of divergence of the vorticity field."""
-        divergence_field = self.buffer_scalar_field.view()
-        self.compute_divergence(
-            divergence=divergence_field,
-            field=self.vorticity_field,
-            inv_dx=(1.0 / self.dx),
-        )
-        vorticity_divg_l2_norm = np.linalg.norm(divergence_field) * self.dx**1.5
-        return vorticity_divg_l2_norm
+    flow_simulator = UnboundedNavierStokesFlowSimulator3D(
+        grid_size=grid_size,
+        x_range=x_range,
+        kinematic_viscosity=kinematic_viscosity,
+        cfl=CFL,
+        real_t=real_t,
+        num_threads=num_threads,
+        time=time,
+        with_forcing=with_forcing,
+        filter_vorticity=filter_vorticity,
+        poisson_solver_type=poisson_solver_type,
+        **kwargs,
+    )
+    return flow_simulator

--- a/sopht/simulator/flow/navier_stokes_flow_simulators.py
+++ b/sopht/simulator/flow/navier_stokes_flow_simulators.py
@@ -1,0 +1,211 @@
+import numpy as np
+from .flow_simulators import FlowSimulator
+from .passive_transport_flow_simulators import (
+    compute_advection_diffusion_stable_time_step,
+)
+import sopht.numeric.eulerian_grid_ops as spne
+import sopht.utils as spu
+from typing import Callable
+
+
+class UnboundedNavierStokesFlowSimulator2D(FlowSimulator):
+    """Class for 2D unbounded Navier Stokes flow simulator"""
+
+    def __init__(
+        self,
+        grid_size: tuple[int, int],
+        x_range: float,
+        kinematic_viscosity: float,
+        cfl: float = 0.1,
+        real_t: type = np.float32,
+        num_threads: int = 1,
+        time: float = 0.0,
+        with_forcing: bool = False,
+        with_free_stream_flow: bool = False,
+        **kwargs,
+    ) -> None:
+        """Class initialiser
+
+        :param grid_size: Grid size of simulator
+        :param x_range: Range of X coordinate of the grid
+        :param kinematic_viscosity: kinematic viscosity of the fluid
+        :param cfl: Courant Freidrich Lewy number (advection timestep)
+        :param real_t: precision of the solver
+        :param num_threads: number of threads
+        :param time: simulator time at initialisation
+        :param with_forcing: flag indicating presence of body forcing
+        :param with_free_stream_flow: flag indicating presence of free stream flow
+
+        Notes
+        -----
+        Currently only supports Euler forward timesteps :(
+        """
+        self.kinematic_viscosity = kinematic_viscosity
+        self.cfl = cfl
+        self.with_forcing = with_forcing
+        self.with_free_stream_flow = with_free_stream_flow
+        self.penalty_zone_width = kwargs.get("penalty_zone_width", 2)
+        super().__init__(
+            grid_dim=2,
+            grid_size=grid_size,
+            x_range=x_range,
+            real_t=real_t,
+            num_threads=num_threads,
+            time=time,
+        )
+
+    def _init_fields(self) -> None:
+        """Initialize the necessary field arrays"""
+        # Initialize flow field
+        self.vorticity_field: np.ndarray = np.zeros(self.grid_size, dtype=self.real_t)
+        self.velocity_field: np.ndarray = np.zeros(
+            (self.grid_dim, *self.grid_size), dtype=self.real_t
+        )
+        # we use the same buffer for advection, diffusion and velocity recovery
+        self.buffer_scalar_field = np.zeros_like(self.vorticity_field)
+        self.stream_func_field = np.zeros_like(self.vorticity_field)
+        if self.with_forcing:
+            # this one holds the forcing from bodies
+            self.eul_grid_forcing_field = np.zeros_like(self.velocity_field)
+
+    def _compile_kernels(self) -> None:
+        """Compile necessary kernels based on simulator flags"""
+        self._diffusion_timestep = (
+            spne.gen_diffusion_timestep_euler_forward_pyst_kernel_2d(
+                real_t=self.real_t,
+                fixed_grid_size=self.grid_size,
+                num_threads=self.num_threads,
+            )
+        )
+        self._advection_timestep = (
+            spne.gen_advection_timestep_euler_forward_conservative_eno3_pyst_kernel_2d(
+                real_t=self.real_t,
+                fixed_grid_size=self.grid_size,
+                num_threads=self.num_threads,
+            )
+        )
+        grid_size_y, grid_size_x = self.grid_size
+        self._unbounded_poisson_solver = spne.UnboundedPoissonSolverPYFFTW2D(
+            grid_size_y=grid_size_y,
+            grid_size_x=grid_size_x,
+            x_range=self.x_range,
+            real_t=self.real_t,
+            num_threads=self.num_threads,
+        )
+        self._curl = spne.gen_outplane_field_curl_pyst_kernel_2d(
+            real_t=self.real_t,
+            num_threads=self.num_threads,
+            fixed_grid_size=self.grid_size,
+        )
+        self._penalise_field_towards_boundary = (
+            spne.gen_penalise_field_boundary_pyst_kernel_2d(
+                width=self.penalty_zone_width,
+                dx=self.dx,
+                x_grid_field=self.position_field[spu.VectorField.x_axis_idx()],
+                y_grid_field=self.position_field[spu.VectorField.y_axis_idx()],
+                real_t=self.real_t,
+                num_threads=self.num_threads,
+                fixed_grid_size=self.grid_size,
+            )
+        )
+        if self.with_forcing:
+            self._update_vorticity_from_velocity_forcing = (
+                spne.gen_update_vorticity_from_velocity_forcing_pyst_kernel_2d(
+                    real_t=self.real_t,
+                    fixed_grid_size=self.grid_size,
+                    num_threads=self.num_threads,
+                )
+            )
+            self._set_field = spne.gen_set_fixed_val_pyst_kernel_2d(
+                real_t=self.real_t,
+                num_threads=self.num_threads,
+                field_type="vector",
+            )
+        if self.with_free_stream_flow:
+            add_fixed_val = spne.gen_add_fixed_val_pyst_kernel_2d(
+                real_t=self.real_t,
+                fixed_grid_size=self.grid_size,
+                num_threads=self.num_threads,
+                field_type="vector",
+            )
+
+            def update_velocity_with_free_stream(
+                free_stream_velocity: np.ndarray,
+            ) -> None:
+                add_fixed_val(
+                    sum_field=self.velocity_field,
+                    vector_field=self.velocity_field,
+                    fixed_vals=free_stream_velocity,
+                )
+
+        else:
+
+            def update_velocity_with_free_stream(
+                free_stream_velocity: np.ndarray,
+            ) -> None:
+                ...
+
+        self._update_velocity_with_free_stream = update_velocity_with_free_stream
+
+    def _finalise_flow_time_step(self) -> None:
+        # defqult time step
+        self._flow_time_step: Callable = self._navier_stokes_time_step
+        if self.with_forcing:
+            self._flow_time_step = self._navier_stokes_with_forcing_time_step
+
+    def _navier_stokes_time_step(
+        self, dt: float, free_stream_velocity: np.ndarray = np.zeros(2)
+    ):
+        # advect vorticity
+        self._advection_timestep(
+            field=self.vorticity_field,
+            advection_flux=self.buffer_scalar_field,
+            velocity=self.velocity_field,
+            dt_by_dx=self.real_t(dt / self.dx),
+        )
+        # diffusion vorticity
+        self._diffusion_timestep(
+            field=self.vorticity_field,
+            diffusion_flux=self.buffer_scalar_field,
+            nu_dt_by_dx2=self.real_t(self.kinematic_viscosity * dt / self.dx / self.dx),
+        )
+        # compute velocity from vorticity
+        self._penalise_field_towards_boundary(field=self.vorticity_field)
+        self._unbounded_poisson_solver.solve(
+            solution_field=self.stream_func_field,
+            rhs_field=self.vorticity_field,
+        )
+        self._curl(
+            curl=self.velocity_field,
+            field=self.stream_func_field,
+            prefactor=self.real_t(0.5 / self.dx),
+        )
+        self._update_velocity_with_free_stream(
+            free_stream_velocity=free_stream_velocity
+        )
+
+    def _navier_stokes_with_forcing_time_step(
+        self, dt: float, free_stream_velocity: np.ndarray = np.zeros(2)
+    ) -> None:
+        self._update_vorticity_from_velocity_forcing(
+            vorticity_field=self.vorticity_field,
+            velocity_forcing_field=self.eul_grid_forcing_field,
+            prefactor=self.real_t(dt / (2 * self.dx)),
+        )
+        self._navier_stokes_time_step(dt=dt, free_stream_velocity=free_stream_velocity)
+        self._set_field(
+            vector_field=self.eul_grid_forcing_field, fixed_vals=[0.0] * self.grid_dim
+        )
+
+    def compute_stable_time_step(self, dt_prefac: float = 1.0) -> float:
+        """Compute upper limit for stable time-stepping."""
+        dt = compute_advection_diffusion_stable_time_step(
+            velocity_field=self.velocity_field,
+            velocity_magnitude_field=self.buffer_scalar_field,
+            grid_dim=self.grid_dim,
+            dx=self.dx,
+            cfl=self.cfl,
+            kinematic_viscosity=self.kinematic_viscosity,
+            real_t=self.real_t,
+        )
+        return dt * dt_prefac

--- a/sopht/simulator/flow/navier_stokes_flow_simulators.py
+++ b/sopht/simulator/flow/navier_stokes_flow_simulators.py
@@ -1,11 +1,12 @@
+import logging
 import numpy as np
 from .flow_simulators import FlowSimulator
 from .passive_transport_flow_simulators import (
-    compute_advection_diffusion_stable_time_step,
+    compute_advection_diffusion_stable_timestep,
 )
 import sopht.numeric.eulerian_grid_ops as spne
 import sopht.utils as spu
-from typing import Callable
+from typing import Callable, Literal
 
 
 class UnboundedNavierStokesFlowSimulator2D(FlowSimulator):
@@ -197,9 +198,9 @@ class UnboundedNavierStokesFlowSimulator2D(FlowSimulator):
             vector_field=self.eul_grid_forcing_field, fixed_vals=[0.0] * self.grid_dim
         )
 
-    def compute_stable_time_step(self, dt_prefac: float = 1.0) -> float:
+    def compute_stable_timestep(self, dt_prefac: float = 1.0) -> float:
         """Compute upper limit for stable time-stepping."""
-        dt = compute_advection_diffusion_stable_time_step(
+        dt = compute_advection_diffusion_stable_timestep(
             velocity_field=self.velocity_field,
             velocity_magnitude_field=self.buffer_scalar_field,
             grid_dim=self.grid_dim,
@@ -209,3 +210,309 @@ class UnboundedNavierStokesFlowSimulator2D(FlowSimulator):
             real_t=self.real_t,
         )
         return dt * dt_prefac
+
+
+class UnboundedNavierStokesFlowSimulator3D(FlowSimulator):
+    """Class for 3D unbounded Navier Stokes flow simulator"""
+
+    def __init__(
+        self,
+        grid_size: tuple[int, int, int],
+        x_range: float,
+        kinematic_viscosity: float,
+        cfl: float = 0.1,
+        real_t: type = np.float32,
+        num_threads: int = 1,
+        time: float = 0.0,
+        with_forcing: bool = False,
+        with_free_stream_flow: bool = False,
+        filter_vorticity: bool = False,
+        poisson_solver_type: Literal[
+            "greens_function_convolution", "fast_diagonalisation"
+        ] = "greens_function_convolution",
+        **kwargs,
+    ) -> None:
+        """Class initialiser
+
+        :param grid_size: Grid size of simulator
+        :param x_range: Range of X coordinate of the grid
+        :param kinematic_viscosity: kinematic viscosity of the fluid
+        :param cfl: Courant Freidrich Lewy number (advection timestep)
+        :param real_t: precision of the solver
+        :param num_threads: number of threads
+        :param time: simulator time at initialisation
+        :param with_forcing: flag indicating presence of body forcing
+        :param with_free_stream_flow: flag indicating presence of free stream flow
+        :param filter_vorticity: flag to determine if vorticity should be filtered or not,
+        needed for stability sometimes
+        :param poisson_solver_type: Type of the poisson solver algorithm, can be
+        "greens_function_convolution" or "fast_diagonalisation"
+
+        Notes
+        -----
+        Currently only supports Euler forward timesteps :(
+        """
+        self.kinematic_viscosity = kinematic_viscosity
+        self.cfl = cfl
+        self.with_forcing = with_forcing
+        self.with_free_stream_flow = with_free_stream_flow
+        self.penalty_zone_width = kwargs.get("penalty_zone_width", 2)
+        self.filter_vorticity = filter_vorticity
+        if self.filter_vorticity:
+            log = logging.getLogger()
+            log.warning(
+                "==============================================="
+                "\nVorticity filtering is turned on."
+            )
+            # default values for the filter setting dictionary
+            default_filter_setting_dict: dict[
+                str, int | Literal["multiplicative", "convolution"]
+            ] = {"order": 2, "type": "multiplicative"}
+            self.filter_setting_dict = kwargs.get(
+                "filter_setting_dict", default_filter_setting_dict
+            )
+            log.warning(
+                f"Setting default filter order = {self.filter_setting_dict['order']}"
+                f"\nand type = {self.filter_setting_dict['type']}. For custom filtering,"
+                "\nprovide a dictionary called 'filter_setting_dict'"
+                "\nwith keys 'order' and 'type'."
+            )
+            log.warning("===============================================")
+        # check validity of poisson solver types
+        supported_poisson_solver_types = [
+            "greens_function_convolution",
+            "fast_diagonalisation",
+        ]
+        self.poisson_solver_type = poisson_solver_type
+        if self.poisson_solver_type not in supported_poisson_solver_types:
+            raise ValueError("Invalid Poisson solver type given")
+        super().__init__(
+            grid_dim=3,
+            grid_size=grid_size,
+            x_range=x_range,
+            real_t=real_t,
+            num_threads=num_threads,
+            time=time,
+        )
+
+    def _init_fields(self) -> None:
+        """Initialize the necessary field arrays in 3D"""
+        # Initialize flow field
+        self.vorticity_field = np.zeros(
+            (self.grid_dim, *self.grid_size), dtype=self.real_t
+        )
+        self.velocity_field = np.zeros_like(self.vorticity_field)
+        # we use the same buffer for advection, diffusion and velocity recovery
+        self.buffer_vector_field = np.zeros_like(self.vorticity_field)
+        self.buffer_scalar_field = self.buffer_vector_field[0].view()
+        self.stream_func_field = np.zeros_like(self.vorticity_field)
+        if self.with_forcing:
+            # this one holds the forcing from bodies
+            self.eul_grid_forcing_field = np.zeros_like(self.velocity_field)
+
+    def _compile_kernels(self) -> None:
+        """Compile necessary kernels based on 3D simulator flags"""
+        self._diffusion_timestep = (
+            spne.gen_diffusion_timestep_euler_forward_pyst_kernel_3d(
+                real_t=self.real_t,
+                fixed_grid_size=self.grid_size,
+                num_threads=self.num_threads,
+                field_type="vector",
+            )
+        )
+        grid_size_z, grid_size_y, grid_size_x = self.grid_size
+        self._unbounded_poisson_solver: spne.UnboundedPoissonSolverPYFFTW3D | spne.FastDiagPoissonSolver3D
+        if self.poisson_solver_type == "greens_function_convolution":
+            self._unbounded_poisson_solver = spne.UnboundedPoissonSolverPYFFTW3D(
+                grid_size_z=grid_size_z,
+                grid_size_y=grid_size_y,
+                grid_size_x=grid_size_x,
+                x_range=self.x_range,
+                real_t=self.real_t,
+                num_threads=self.num_threads,
+            )
+        elif self.poisson_solver_type == "fast_diagonalisation":
+            self._unbounded_poisson_solver = spne.FastDiagPoissonSolver3D(
+                grid_size_z=grid_size_z,
+                grid_size_y=grid_size_y,
+                grid_size_x=grid_size_x,
+                dx=self.dx,
+                real_t=self.real_t,
+                # TODO add different options here later
+                bc_type="homogenous_neumann_along_xyz",
+            )
+        self._curl = spne.gen_curl_pyst_kernel_3d(
+            real_t=self.real_t,
+            num_threads=self.num_threads,
+            fixed_grid_size=self.grid_size,
+        )
+        self._penalise_field_towards_boundary = (
+            spne.gen_penalise_field_boundary_pyst_kernel_3d(
+                width=self.penalty_zone_width,
+                dx=self.dx,
+                x_grid_field=self.position_field[spu.VectorField.x_axis_idx()],
+                y_grid_field=self.position_field[spu.VectorField.y_axis_idx()],
+                z_grid_field=self.position_field[spu.VectorField.z_axis_idx()],
+                real_t=self.real_t,
+                num_threads=self.num_threads,
+                fixed_grid_size=self.grid_size,
+                field_type="vector",
+            )
+        )
+        self._elementwise_cross_product = (
+            spne.gen_elementwise_cross_product_pyst_kernel_3d(
+                real_t=self.real_t,
+                num_threads=self.num_threads,
+                fixed_grid_size=self.grid_size,
+            )
+        )
+        self._update_vorticity_from_velocity_forcing = (
+            spne.gen_update_vorticity_from_velocity_forcing_pyst_kernel_3d(
+                real_t=self.real_t,
+                fixed_grid_size=self.grid_size,
+                num_threads=self.num_threads,
+            )
+        )
+        # check if vorticity stays divergence free
+        self._compute_divergence = spne.gen_divergence_pyst_kernel_3d(
+            real_t=self.real_t,
+            fixed_grid_size=self.grid_size,
+            num_threads=self.num_threads,
+        )
+
+        # filter kernel compilation
+        def filter_vector_field(vector_field: np.ndarray) -> None:
+            ...
+
+        self._filter_vector_field = filter_vector_field
+        if self.filter_vorticity and self.filter_setting_dict is not None:
+            self._filter_vector_field = spne.gen_laplacian_filter_kernel_3d(
+                filter_order=self.filter_setting_dict["order"],
+                filter_flux_buffer=self.buffer_vector_field[0],
+                field_buffer=self.buffer_vector_field[1],
+                real_t=self.real_t,
+                num_threads=self.num_threads,
+                fixed_grid_size=self.grid_size,
+                field_type="vector",
+                filter_type=self.filter_setting_dict["type"],
+            )
+
+        if self.with_forcing:
+            self._set_field = spne.gen_set_fixed_val_pyst_kernel_3d(
+                real_t=self.real_t,
+                num_threads=self.num_threads,
+                field_type="vector",
+            )
+
+        if self.with_free_stream_flow:
+            add_fixed_val = spne.gen_add_fixed_val_pyst_kernel_3d(
+                real_t=self.real_t,
+                fixed_grid_size=self.grid_size,
+                num_threads=self.num_threads,
+                field_type="vector",
+            )
+
+            def update_velocity_with_free_stream(
+                free_stream_velocity: np.ndarray,
+            ) -> None:
+                add_fixed_val(
+                    sum_field=self.velocity_field,
+                    vector_field=self.velocity_field,
+                    fixed_vals=free_stream_velocity,
+                )
+
+        else:
+
+            def update_velocity_with_free_stream(
+                free_stream_velocity: np.ndarray,
+            ) -> None:
+                ...
+
+        self._update_velocity_with_free_stream = update_velocity_with_free_stream
+
+    def _finalise_flow_time_step(self) -> None:
+        # defqult time step
+        self._flow_time_step: Callable = self._navier_stokes_time_step
+        if self.with_forcing:
+            self._flow_time_step = self._navier_stokes_with_forcing_time_step
+
+    def _navier_stokes_time_step(
+        self,
+        dt: float,
+        free_stream_velocity: np.ndarray = np.zeros(3),
+    ) -> None:
+        # advection and stretching vorticity together in rotational form
+        velocity_cross_vorticity = self.buffer_vector_field.view()
+        self._elementwise_cross_product(
+            result_field=velocity_cross_vorticity,
+            field_1=self.velocity_field,
+            field_2=self.vorticity_field,
+        )
+        self._update_vorticity_from_velocity_forcing(
+            vorticity_field=self.vorticity_field,
+            velocity_forcing_field=velocity_cross_vorticity,
+            prefactor=self.real_t(dt / (2 * self.dx)),
+        )
+        # diffuse vorticity
+        self._diffusion_timestep(
+            vector_field=self.vorticity_field,
+            diffusion_flux=self.buffer_scalar_field,
+            nu_dt_by_dx2=self.real_t(self.kinematic_viscosity * dt / self.dx / self.dx),
+        )
+        # filter vorticity for stability
+        self._filter_vector_field(vector_field=self.vorticity_field)
+        # compute velocity from vorticity
+        self._penalise_field_towards_boundary(vector_field=self.vorticity_field)
+        self._unbounded_poisson_solver.vector_field_solve(
+            solution_vector_field=self.stream_func_field,
+            rhs_vector_field=self.vorticity_field,
+        )
+        self._curl(
+            curl=self.velocity_field,
+            field=self.stream_func_field,
+            prefactor=self.real_t(0.5 / self.dx),
+        )
+        self._update_velocity_with_free_stream(
+            free_stream_velocity=free_stream_velocity
+        )
+
+    def _navier_stokes_with_forcing_time_step(
+        self,
+        dt: float,
+        free_stream_velocity: np.ndarray = np.zeros(3),
+    ) -> None:
+        self._update_vorticity_from_velocity_forcing(
+            vorticity_field=self.vorticity_field,
+            velocity_forcing_field=self.eul_grid_forcing_field,
+            prefactor=self.real_t(dt / (2 * self.dx)),
+        )
+        self._navier_stokes_time_step(dt=dt, free_stream_velocity=free_stream_velocity)
+        self._set_field(
+            vector_field=self.eul_grid_forcing_field, fixed_vals=[0.0] * self.grid_dim
+        )
+
+    def compute_stable_timestep(self, dt_prefac: float = 1.0) -> float:
+        """Compute upper limit for stable time-stepping."""
+        dt = compute_advection_diffusion_stable_timestep(
+            velocity_field=self.velocity_field,
+            velocity_magnitude_field=self.buffer_scalar_field,
+            grid_dim=self.grid_dim,
+            dx=self.dx,
+            cfl=self.cfl,
+            kinematic_viscosity=self.kinematic_viscosity,
+            real_t=self.real_t,
+        )
+        return dt * dt_prefac
+
+    def get_vorticity_divergence_l2_norm(self) -> float:
+        """Return L2 norm of divergence of the vorticity field."""
+        divergence_field = self.buffer_scalar_field.view()
+        self._compute_divergence(
+            divergence=divergence_field,
+            field=self.vorticity_field,
+            inv_dx=(1.0 / self.dx),
+        )
+        vorticity_divg_l2_norm = np.linalg.norm(divergence_field) * self.dx ** (
+            self.grid_dim / 2.0
+        )
+        return vorticity_divg_l2_norm

--- a/sopht/simulator/flow/passive_transport_flow_simulators.py
+++ b/sopht/simulator/flow/passive_transport_flow_simulators.py
@@ -113,9 +113,9 @@ class PassiveTransportFlowSimulator(FlowSimulator):
         """Finalise the flow time step"""
         self._flow_time_step: Callable = self._advection_and_diffusion_time_step
 
-    def compute_stable_time_step(self, dt_prefac: float = 1.0) -> float:
+    def compute_stable_timestep(self, dt_prefac: float = 1.0) -> float:
         """Compute upper limit for stable time-stepping."""
-        dt = compute_advection_diffusion_stable_time_step(
+        dt = compute_advection_diffusion_stable_timestep(
             velocity_field=self.velocity_field,
             velocity_magnitude_field=self.buffer_scalar_field,
             grid_dim=self.grid_dim,
@@ -127,7 +127,7 @@ class PassiveTransportFlowSimulator(FlowSimulator):
         return dt * dt_prefac
 
 
-def compute_advection_diffusion_stable_time_step(
+def compute_advection_diffusion_stable_timestep(
     velocity_field: np.ndarray,
     velocity_magnitude_field: np.ndarray,
     grid_dim: int,

--- a/sopht/simulator/flow/passive_transport_flow_simulators.py
+++ b/sopht/simulator/flow/passive_transport_flow_simulators.py
@@ -1,0 +1,147 @@
+import numpy as np
+from .flow_simulators import FlowSimulator
+import sopht.numeric.eulerian_grid_ops as spne
+from typing import Callable, Literal, Type
+
+
+class PassiveTransportFlowSimulator(FlowSimulator):
+    """Class for passive transport flow simulator.
+
+    Solves advection diffusion equations for a passive scalar
+    or vector field.
+    """
+
+    def __init__(
+        self,
+        kinematic_viscosity: float,
+        grid_dim: int,
+        grid_size: tuple[int, int] | tuple[int, int, int],
+        x_range: float,
+        cfl: float = 0.1,
+        real_t: Type = np.float32,
+        num_threads: int = 1,
+        time: float = 0.0,
+        field_type: Literal["scalar", "vector"] = "scalar",
+    ) -> None:
+        """Class initialiser
+
+        :param kinematic_viscosity: kinematic viscosity
+        :param grid_dim: grid dimensions
+        :param grid_size: Grid size of simulator
+        :param x_range: Range of X coordinate of the grid
+        :param cfl: Courant Fredreich Lewy number
+        :param real_t: precision of the solver
+        :param num_threads: number of threads
+        :param time: simulator time at initialisation
+        :param field_type: type of primary field (scalar or vector)
+
+        """
+        if field_type not in ["scalar", "vector"]:
+            raise ValueError(
+                "Invalid field type. Supported values include 'scalar' and 'vector'"
+            )
+        # TODO add support for passive transport of vector field in 2D
+        if grid_dim == 2 and field_type == "vector":
+            raise ValueError("Passive transport of vector 2D fields not supported yet.")
+        self.kinematic_viscosity = kinematic_viscosity
+        self.cfl = cfl
+        self.field_type = field_type
+        super().__init__(grid_dim, grid_size, x_range, real_t, num_threads, time)
+
+    def _init_fields(self) -> None:
+        """Initialize the necessary field arrays"""
+        match self.field_type:
+            case "scalar":
+                self.primary_field = np.zeros(self.grid_size, dtype=self.real_t)
+            case "vector":
+                self.primary_field = np.zeros(
+                    (self.grid_dim, *self.grid_size), dtype=self.real_t
+                )
+        self.velocity_field = np.zeros(
+            (self.grid_dim, *self.grid_size), dtype=self.real_t
+        )
+        # we use the same buffer for advection and diffusion fluxes
+        self.buffer_scalar_field = np.zeros(self.grid_size, dtype=self.real_t)
+
+    def _compile_kernels(self) -> None:
+        """Compile necessary kernels based on flow type"""
+        match self.grid_dim:
+            case 2:
+                self._diffusion_timestep = (
+                    spne.gen_diffusion_timestep_euler_forward_pyst_kernel_2d(
+                        real_t=self.real_t,
+                        fixed_grid_size=self.grid_size,
+                        num_threads=self.num_threads,
+                    )
+                )
+                self._advection_timestep = spne.gen_advection_timestep_euler_forward_conservative_eno3_pyst_kernel_2d(
+                    real_t=self.real_t,
+                    fixed_grid_size=self.grid_size,
+                    num_threads=self.num_threads,
+                )
+            case 3:
+                self._diffusion_timestep = (
+                    spne.gen_diffusion_timestep_euler_forward_pyst_kernel_3d(
+                        real_t=self.real_t,
+                        fixed_grid_size=self.grid_size,
+                        num_threads=self.num_threads,
+                        field_type=self.field_type,
+                    )
+                )
+                self._advection_timestep = spne.gen_advection_timestep_euler_forward_conservative_eno3_pyst_kernel_3d(
+                    real_t=self.real_t,
+                    fixed_grid_size=self.grid_size,
+                    num_threads=self.num_threads,
+                    field_type=self.field_type,
+                )
+
+    def _advection_and_diffusion_time_step(self, dt: float, **kwargs) -> None:
+        """Advection and diffusion time step"""
+        self._advection_timestep(
+            self.primary_field,
+            advection_flux=self.buffer_scalar_field,
+            velocity=self.velocity_field,
+            dt_by_dx=self.real_t(dt / self.dx),
+        )
+        self._diffusion_timestep(
+            self.primary_field,
+            diffusion_flux=self.buffer_scalar_field,
+            nu_dt_by_dx2=self.real_t(self.kinematic_viscosity * dt / self.dx / self.dx),
+        )
+
+    def _finalise_flow_time_step(self) -> None:
+        """Finalise the flow time step"""
+        self._flow_time_step: Callable = self._advection_and_diffusion_time_step
+
+    def compute_stable_time_step(self, dt_prefac: float = 1.0) -> float:
+        """Compute upper limit for stable time-stepping."""
+        dt = compute_advection_diffusion_stable_time_step(
+            velocity_field=self.velocity_field,
+            velocity_magnitude_field=self.buffer_scalar_field,
+            grid_dim=self.grid_dim,
+            dx=self.dx,
+            cfl=self.cfl,
+            kinematic_viscosity=self.kinematic_viscosity,
+            real_t=self.real_t,
+        )
+        return dt * dt_prefac
+
+
+def compute_advection_diffusion_stable_time_step(
+    velocity_field: np.ndarray,
+    velocity_magnitude_field: np.ndarray,
+    grid_dim: int,
+    dx: float,
+    cfl: float,
+    kinematic_viscosity: float,
+    real_t: type = np.float32,
+) -> float:
+    """Compute stable timestep based on advection and diffusion limits."""
+    # This may need a numba or pystencil version
+    tol = 10 * np.finfo(real_t).eps
+    velocity_magnitude_field[...] = np.sum(np.fabs(velocity_field), axis=0)
+    dt = min(
+        cfl * dx / (np.amax(velocity_magnitude_field) + tol),
+        0.9 * dx**2 / (2 * grid_dim) / kinematic_viscosity + tol,
+    )
+    return dt

--- a/tests/test_simulator/test_flow/test_flow_simulators_2d.py
+++ b/tests/test_simulator/test_flow/test_flow_simulators_2d.py
@@ -1,16 +1,7 @@
 import numpy as np
 import pytest
 import sopht.simulator as sps
-from sopht.numeric.eulerian_grid_ops import (
-    gen_advection_timestep_euler_forward_conservative_eno3_pyst_kernel_2d,
-    gen_diffusion_timestep_euler_forward_pyst_kernel_2d,
-    gen_penalise_field_boundary_pyst_kernel_2d,
-    gen_outplane_field_curl_pyst_kernel_2d,
-    gen_update_vorticity_from_velocity_forcing_pyst_kernel_2d,
-    UnboundedPoissonSolverPYFFTW2D,
-)
-from sopht.utils.precision import get_real_t, get_test_tol
-from sopht.utils.field import VectorField
+from sopht.utils.precision import get_real_t
 
 
 @pytest.mark.parametrize("grid_size_x", [8, 16])
@@ -25,7 +16,6 @@ def test_flow_sim_2d_navier_stokes_with_forcing_timestep(
     nu = 1.0
     real_t = get_real_t(precision)
     grid_size = (grid_size_x,) * grid_dim
-    dx = real_t(x_range / grid_size_x)
     dt = 2.0
     free_stream_velocity = np.array([3.0, 4.0])
     init_time = 1.0
@@ -39,7 +29,6 @@ def test_flow_sim_2d_navier_stokes_with_forcing_timestep(
         num_threads=num_threads,
         time=init_time,
     )
-    ref_time = init_time + dt
     # initialise flow sim state (vorticity and forcing)
     flow_sim.vorticity_field[...] = np.random.rand(
         *flow_sim.vorticity_field.shape
@@ -50,91 +39,27 @@ def test_flow_sim_2d_navier_stokes_with_forcing_timestep(
     flow_sim.eul_grid_forcing_field[...] = np.random.rand(
         *flow_sim.eul_grid_forcing_field.shape
     ).astype(real_t)
-    ref_vorticity_field = flow_sim.vorticity_field.copy()
-    ref_velocity_field = flow_sim.velocity_field.copy()
-    ref_eul_grid_forcing_field = flow_sim.eul_grid_forcing_field.copy()
-    flow_sim.time_step(dt=dt, free_stream_velocity=free_stream_velocity)
-
-    # next we setup the reference timestep manually
-    # first we compile necessary kernels
-    diffusion_timestep = gen_diffusion_timestep_euler_forward_pyst_kernel_2d(
-        real_t=real_t,
-        fixed_grid_size=grid_size,
-        num_threads=num_threads,
-    )
-    advection_timestep = (
-        gen_advection_timestep_euler_forward_conservative_eno3_pyst_kernel_2d(
-            real_t=real_t,
-            fixed_grid_size=grid_size,
-            num_threads=num_threads,
-        )
-    )
-    grid_size_y, grid_size_x = grid_size
-    unbounded_poisson_solver = UnboundedPoissonSolverPYFFTW2D(
-        grid_size_y=grid_size_y,
-        grid_size_x=grid_size_x,
+    # generate reference simulator
+    ref_flow_sim = sps.UnboundedNavierStokesFlowSimulator2D(
+        grid_size=grid_size,
         x_range=x_range,
+        kinematic_viscosity=nu,
+        with_forcing=True,
+        with_free_stream_flow=with_free_stream,
         real_t=real_t,
         num_threads=num_threads,
+        time=init_time,
     )
-    curl = gen_outplane_field_curl_pyst_kernel_2d(
-        real_t=real_t,
-        num_threads=num_threads,
-        fixed_grid_size=grid_size,
-    )
-    penalise_field_towards_boundary = gen_penalise_field_boundary_pyst_kernel_2d(
-        width=flow_sim.penalty_zone_width,
-        dx=dx,
-        x_grid_field=flow_sim.position_field[VectorField.x_axis_idx()],
-        y_grid_field=flow_sim.position_field[VectorField.y_axis_idx()],
-        real_t=real_t,
-        num_threads=num_threads,
-        fixed_grid_size=grid_size,
-    )
-    update_vorticity_from_velocity_forcing = (
-        gen_update_vorticity_from_velocity_forcing_pyst_kernel_2d(
-            real_t=real_t,
-            fixed_grid_size=grid_size,
-            num_threads=num_threads,
-        )
-    )
+    ref_flow_sim.vorticity_field[...] = flow_sim.vorticity_field.copy()
+    ref_flow_sim.velocity_field[...] = flow_sim.velocity_field.copy()
+    ref_flow_sim.eul_grid_forcing_field[...] = flow_sim.eul_grid_forcing_field.copy()
+    flow_sim.time_step(dt=dt, free_stream_velocity=free_stream_velocity)
+    ref_flow_sim.time_step(dt=dt, free_stream_velocity=free_stream_velocity)
 
-    # manually timestep
-    update_vorticity_from_velocity_forcing(
-        vorticity_field=ref_vorticity_field,
-        velocity_forcing_field=ref_eul_grid_forcing_field,
-        prefactor=real_t(dt / (2 * dx)),
-    )
-    flux_buffer = np.zeros(grid_size, dtype=real_t)
-    advection_timestep(
-        field=ref_vorticity_field,
-        advection_flux=flux_buffer,
-        velocity=ref_velocity_field,
-        dt_by_dx=real_t(dt / dx),
-    )
-    diffusion_timestep(
-        field=ref_vorticity_field,
-        diffusion_flux=flux_buffer,
-        nu_dt_by_dx2=real_t(nu * dt / dx / dx),
-    )
-    penalise_field_towards_boundary(field=ref_vorticity_field)
-    stream_func_field = np.zeros(grid_size, dtype=real_t)
-    unbounded_poisson_solver.solve(
-        solution_field=stream_func_field,
-        rhs_field=ref_vorticity_field,
-    )
-    curl(
-        curl=ref_velocity_field,
-        field=stream_func_field,
-        prefactor=real_t(0.5 / dx),
-    )
-    if with_free_stream:
-        ref_velocity_field[...] += free_stream_velocity.reshape(grid_dim, 1, 1)
-
-    assert flow_sim.time == ref_time
+    assert flow_sim.time == ref_flow_sim.time
     np.testing.assert_allclose(flow_sim.eul_grid_forcing_field, 0.0)
-    np.testing.assert_allclose(flow_sim.vorticity_field, ref_vorticity_field)
-    np.testing.assert_allclose(flow_sim.velocity_field, ref_velocity_field)
+    np.testing.assert_allclose(flow_sim.vorticity_field, ref_flow_sim.vorticity_field)
+    np.testing.assert_allclose(flow_sim.velocity_field, ref_flow_sim.velocity_field)
 
 
 @pytest.mark.parametrize("grid_size_x", [8, 16])
@@ -143,10 +68,9 @@ def test_flow_sim_2d_compute_stable_timestep(grid_size_x, precision):
     num_threads = 4
     grid_dim = 2
     x_range = 1.0
-    nu = 1.0
+    nu = 1e-2
     real_t = get_real_t(precision)
     grid_size = (grid_size_x,) * grid_dim
-    dx = real_t(x_range / grid_size_x)
     cfl = 0.2
     flow_sim = sps.UnboundedFlowSimulator2D(
         grid_size=grid_size,
@@ -158,11 +82,16 @@ def test_flow_sim_2d_compute_stable_timestep(grid_size_x, precision):
     )
     flow_sim.velocity_field[...] = 2.0
     dt_prefac = 0.5
-    sim_dt = flow_sim.compute_stable_timestep(dt_prefac=dt_prefac, precision=precision)
-    # next compute reference value
-    advection_limit_dt = (
-        cfl * dx / (grid_dim * 2.0 + get_test_tol(precision))
-    )  # max(sum(abs(velocity_field)))
-    diffusion_limit_dt = 0.9 * dx**2 / 4 / nu
-    ref_dt = dt_prefac * min(advection_limit_dt, diffusion_limit_dt)
+    sim_dt = flow_sim.compute_stable_timestep(dt_prefac=dt_prefac)
+    # generate reference simulator
+    ref_flow_sim = sps.UnboundedNavierStokesFlowSimulator2D(
+        grid_size=grid_size,
+        x_range=x_range,
+        cfl=cfl,
+        kinematic_viscosity=nu,
+        real_t=real_t,
+        num_threads=num_threads,
+    )
+    ref_flow_sim.velocity_field[...] = 2.0
+    ref_dt = ref_flow_sim.compute_stable_timestep(dt_prefac=dt_prefac)
     assert ref_dt == sim_dt

--- a/tests/test_simulator/test_flow/test_flow_simulators_3d.py
+++ b/tests/test_simulator/test_flow/test_flow_simulators_3d.py
@@ -2,102 +2,6 @@ import numpy as np
 import pytest
 import sopht.utils as spu
 import sopht.simulator as sps
-import sopht.numeric.eulerian_grid_ops as spne
-
-
-@pytest.mark.parametrize("grid_size_x", [4, 8])
-@pytest.mark.parametrize("precision", ["single", "double"])
-@pytest.mark.parametrize("field_type", ["scalar", "vector"])
-def test_flow_sim_3d_advection_and_diffusion_timestep(
-    field_type,
-    grid_size_x,
-    precision,
-):
-    num_threads = 4
-    grid_dim = 3
-    x_range = 1.0
-    nu = 1e-2
-    real_t = spu.get_real_t(precision)
-    grid_size = (grid_size_x,) * grid_dim
-    dx = real_t(x_range / grid_size_x)
-    dt = 2.0
-    init_time = 1.0
-    flow_sim = sps.UnboundedFlowSimulator3D(
-        grid_size=grid_size,
-        x_range=x_range,
-        kinematic_viscosity=nu,
-        flow_type="passive_" + field_type,
-        real_t=real_t,
-        num_threads=num_threads,
-        time=init_time,
-    )
-    ref_time = init_time + dt
-    # initialise flow sim state (passive fields)
-    flow_sim.velocity_field[...] = np.random.rand(
-        *flow_sim.velocity_field.shape
-    ).astype(real_t)
-    ref_primary_field = None
-    match field_type:
-        case "scalar":
-            flow_sim.primary_scalar_field[...] = np.random.rand(
-                *flow_sim.primary_scalar_field.shape
-            ).astype(real_t)
-            ref_primary_field = flow_sim.primary_scalar_field.copy()
-        case "vector":
-            flow_sim.primary_vector_field[...] = np.random.rand(
-                *flow_sim.primary_vector_field.shape
-            ).astype(real_t)
-            ref_primary_field = flow_sim.primary_vector_field.copy()
-    flow_sim.time_step(dt=dt)
-
-    # next we setup the reference timestep manually
-    # first we compile necessary kernels
-    diffusion_timestep = spne.gen_diffusion_timestep_euler_forward_pyst_kernel_3d(
-        real_t=real_t,
-        fixed_grid_size=grid_size,
-        num_threads=num_threads,
-        field_type=field_type,
-    )
-    advection_timestep = (
-        spne.gen_advection_timestep_euler_forward_conservative_eno3_pyst_kernel_3d(
-            real_t=real_t,
-            fixed_grid_size=grid_size,
-            num_threads=num_threads,
-            field_type=field_type,
-        )
-    )
-    # manually timestep
-    match field_type:
-        case "scalar":
-            advection_timestep(
-                field=ref_primary_field,
-                advection_flux=np.zeros_like(ref_primary_field),
-                velocity=flow_sim.velocity_field,
-                dt_by_dx=real_t(dt / dx),
-            )
-            diffusion_timestep(
-                field=ref_primary_field,
-                diffusion_flux=np.zeros_like(ref_primary_field),
-                nu_dt_by_dx2=real_t(nu * dt / dx / dx),
-            )
-        case "vector":
-            advection_timestep(
-                vector_field=ref_primary_field,
-                advection_flux=np.zeros_like(ref_primary_field[0]),
-                velocity=flow_sim.velocity_field,
-                dt_by_dx=real_t(dt / dx),
-            )
-            diffusion_timestep(
-                vector_field=ref_primary_field,
-                diffusion_flux=np.zeros_like(ref_primary_field[0]),
-                nu_dt_by_dx2=real_t(nu * dt / dx / dx),
-            )
-    assert flow_sim.time == ref_time
-    match field_type:
-        case "scalar":
-            np.testing.assert_allclose(flow_sim.primary_scalar_field, ref_primary_field)
-        case "vector":
-            np.testing.assert_allclose(flow_sim.primary_vector_field, ref_primary_field)
 
 
 @pytest.mark.parametrize("grid_size_x", [4, 8])
@@ -116,7 +20,6 @@ def test_flow_sim_3d_navier_stokes_with_forcing_timestep(
     nu = 1e-2
     real_t = spu.get_real_t(precision)
     grid_size = (grid_size_x,) * grid_dim
-    dx = real_t(x_range / grid_size_x)
     dt = 2.0
     free_stream_velocity = np.array([3.0, 4.0, 5.0])
     init_time = 1.0
@@ -134,7 +37,6 @@ def test_flow_sim_3d_navier_stokes_with_forcing_timestep(
         filter_vorticity=filter_vorticity,
         filter_setting_dict={"type": filter_type, "order": filter_order},
     )
-    ref_time = init_time + dt
     # initialise flow sim state (vorticity and forcing)
     flow_sim.vorticity_field[...] = np.random.rand(
         *flow_sim.vorticity_field.shape
@@ -145,114 +47,29 @@ def test_flow_sim_3d_navier_stokes_with_forcing_timestep(
     flow_sim.eul_grid_forcing_field[...] = np.random.rand(
         *flow_sim.eul_grid_forcing_field.shape
     ).astype(real_t)
-    ref_vorticity_field = flow_sim.vorticity_field.copy()
-    ref_velocity_field = flow_sim.velocity_field.copy()
-    ref_eul_grid_forcing_field = flow_sim.eul_grid_forcing_field.copy()
-    flow_sim.time_step(dt=dt, free_stream_velocity=free_stream_velocity)
-
-    # next we setup the reference timestep manually
-    # first we compile necessary kernels
-    diffusion_timestep = spne.gen_diffusion_timestep_euler_forward_pyst_kernel_3d(
-        real_t=real_t,
-        fixed_grid_size=grid_size,
-        num_threads=num_threads,
-        field_type="vector",
-    )
-    elementwise_cross_product = spne.gen_elementwise_cross_product_pyst_kernel_3d(
-        real_t=real_t,
-        num_threads=num_threads,
-        fixed_grid_size=grid_size,
-    )
-    grid_size_z, grid_size_y, grid_size_x = grid_size
-    unbounded_poisson_solver = spne.UnboundedPoissonSolverPYFFTW3D(
-        grid_size_z=grid_size_z,
-        grid_size_y=grid_size_y,
-        grid_size_x=grid_size_x,
+    # generate reference simulator
+    ref_flow_sim = sps.UnboundedNavierStokesFlowSimulator3D(
+        grid_size=grid_size,
         x_range=x_range,
+        kinematic_viscosity=nu,
+        with_forcing=True,
+        with_free_stream_flow=with_free_stream,
         real_t=real_t,
         num_threads=num_threads,
+        time=init_time,
+        filter_vorticity=filter_vorticity,
+        filter_setting_dict={"type": filter_type, "order": filter_order},
     )
-    curl = spne.gen_curl_pyst_kernel_3d(
-        real_t=real_t,
-        num_threads=num_threads,
-        fixed_grid_size=grid_size,
-    )
-    penalise_field_towards_boundary = spne.gen_penalise_field_boundary_pyst_kernel_3d(
-        width=flow_sim.penalty_zone_width,
-        dx=dx,
-        x_grid_field=flow_sim.position_field[spu.VectorField.x_axis_idx()],
-        y_grid_field=flow_sim.position_field[spu.VectorField.y_axis_idx()],
-        z_grid_field=flow_sim.position_field[spu.VectorField.z_axis_idx()],
-        real_t=real_t,
-        num_threads=num_threads,
-        fixed_grid_size=grid_size,
-        field_type="vector",
-    )
-    update_vorticity_from_velocity_forcing = (
-        spne.gen_update_vorticity_from_velocity_forcing_pyst_kernel_3d(
-            real_t=real_t,
-            fixed_grid_size=grid_size,
-            num_threads=num_threads,
-        )
-    )
-    if filter_vorticity:
-        filter_vector_field = spne.gen_laplacian_filter_kernel_3d(
-            filter_flux_buffer=np.zeros_like(ref_vorticity_field[0]),
-            field_buffer=np.zeros_like(ref_vorticity_field[0]),
-            real_t=real_t,
-            num_threads=num_threads,
-            fixed_grid_size=grid_size,
-            field_type="vector",
-            filter_order=filter_order,
-            filter_type=filter_type,
-        )
-    else:
+    ref_flow_sim.vorticity_field[...] = flow_sim.vorticity_field.copy()
+    ref_flow_sim.velocity_field[...] = flow_sim.velocity_field.copy()
+    ref_flow_sim.eul_grid_forcing_field[...] = flow_sim.eul_grid_forcing_field.copy()
+    flow_sim.time_step(dt=dt, free_stream_velocity=free_stream_velocity)
+    ref_flow_sim.time_step(dt=dt, free_stream_velocity=free_stream_velocity)
 
-        def filter_vector_field(vector_field):
-            ...
-
-    # manually timestep
-    update_vorticity_from_velocity_forcing(
-        vorticity_field=ref_vorticity_field,
-        velocity_forcing_field=ref_eul_grid_forcing_field,
-        prefactor=real_t(dt / (2 * dx)),
-    )
-    velocity_cross_vorticity = np.zeros_like(ref_vorticity_field)
-    elementwise_cross_product(
-        result_field=velocity_cross_vorticity,
-        field_1=ref_velocity_field,
-        field_2=ref_vorticity_field,
-    )
-    update_vorticity_from_velocity_forcing(
-        vorticity_field=ref_vorticity_field,
-        velocity_forcing_field=velocity_cross_vorticity,
-        prefactor=real_t(dt / (2 * dx)),
-    )
-    flux_buffer = np.zeros(grid_size, dtype=real_t)
-    diffusion_timestep(
-        vector_field=ref_vorticity_field,
-        diffusion_flux=flux_buffer,
-        nu_dt_by_dx2=real_t(nu * dt / dx / dx),
-    )
-    filter_vector_field(vector_field=ref_vorticity_field)
-    penalise_field_towards_boundary(vector_field=ref_vorticity_field)
-    stream_func_field = np.zeros_like(ref_vorticity_field)
-    unbounded_poisson_solver.vector_field_solve(
-        solution_vector_field=stream_func_field,
-        rhs_vector_field=ref_vorticity_field,
-    )
-    curl(
-        curl=ref_velocity_field,
-        field=stream_func_field,
-        prefactor=real_t(0.5 / dx),
-    )
-    if with_free_stream:
-        ref_velocity_field[...] += free_stream_velocity.reshape((grid_dim, 1, 1, 1))
-
-    assert flow_sim.time == ref_time
+    assert flow_sim.time == ref_flow_sim.time
     np.testing.assert_allclose(flow_sim.eul_grid_forcing_field, 0.0)
-    np.testing.assert_allclose(flow_sim.vorticity_field, ref_vorticity_field)
-    np.testing.assert_allclose(flow_sim.velocity_field, ref_velocity_field)
+    np.testing.assert_allclose(flow_sim.vorticity_field, ref_flow_sim.vorticity_field)
+    np.testing.assert_allclose(flow_sim.velocity_field, ref_flow_sim.velocity_field)
 
 
 @pytest.mark.parametrize("grid_size_x", [4, 8])
@@ -264,7 +81,6 @@ def test_flow_sim_3d_compute_stable_timestep(grid_size_x, precision):
     nu = 1e-2
     real_t = spu.get_real_t(precision)
     grid_size = (grid_size_x,) * grid_dim
-    dx = real_t(x_range / grid_size_x)
     cfl = 0.2
     flow_sim = sps.UnboundedFlowSimulator3D(
         grid_size=grid_size,
@@ -276,13 +92,18 @@ def test_flow_sim_3d_compute_stable_timestep(grid_size_x, precision):
     )
     flow_sim.velocity_field[...] = 2.0
     dt_prefac = 0.5
-    sim_dt = flow_sim.compute_stable_timestep(dt_prefac=dt_prefac, precision=precision)
-    # next compute reference value
-    advection_limit_dt = (
-        cfl * dx / (grid_dim * 2.0 + spu.get_test_tol(precision))
-    )  # max(sum(abs(velocity_field)))
-    diffusion_limit_dt = 0.9 * dx**2 / 6 / nu
-    ref_dt = dt_prefac * min(advection_limit_dt, diffusion_limit_dt)
+    sim_dt = flow_sim.compute_stable_timestep(dt_prefac=dt_prefac)
+    # generate reference simulator
+    ref_flow_sim = sps.UnboundedNavierStokesFlowSimulator3D(
+        grid_size=grid_size,
+        x_range=x_range,
+        cfl=cfl,
+        kinematic_viscosity=nu,
+        real_t=real_t,
+        num_threads=num_threads,
+    )
+    ref_flow_sim.velocity_field[...] = 2.0
+    ref_dt = ref_flow_sim.compute_stable_timestep(dt_prefac=dt_prefac)
     assert ref_dt == sim_dt
 
 
@@ -295,7 +116,6 @@ def test_flow_sim_3d_get_vorticity_divergence_l2_norm(grid_size_x, precision):
     nu = 1e-2
     real_t = spu.get_real_t(precision)
     grid_size = (grid_size_x,) * grid_dim
-    dx = real_t(x_range / grid_size_x)
     cfl = 0.2
     flow_sim = sps.UnboundedFlowSimulator3D(
         grid_size=grid_size,
@@ -304,22 +124,18 @@ def test_flow_sim_3d_get_vorticity_divergence_l2_norm(grid_size_x, precision):
         kinematic_viscosity=nu,
         real_t=real_t,
         num_threads=num_threads,
-        flow_type="navier_stokes_with_forcing",
     )
     flow_sim.vorticity_field[...] = np.random.rand(grid_dim, *grid_size)
     vorticity_divergence_l2_norm = flow_sim.get_vorticity_divergence_l2_norm()
-
-    # compute manually
-    compute_divergence = spne.gen_divergence_pyst_kernel_3d(
+    # generate reference simulator
+    ref_flow_sim = sps.UnboundedNavierStokesFlowSimulator3D(
+        grid_size=grid_size,
+        x_range=x_range,
+        cfl=cfl,
+        kinematic_viscosity=nu,
         real_t=real_t,
-        fixed_grid_size=grid_size,
         num_threads=num_threads,
     )
-    divergence_field = np.zeros_like(flow_sim.vorticity_field[0])
-    compute_divergence(
-        divergence=divergence_field,
-        field=flow_sim.vorticity_field,
-        inv_dx=(1.0 / dx),
-    )
-    ref_vorticity_divg_l2_norm = np.linalg.norm(divergence_field) * dx**1.5
+    ref_flow_sim.vorticity_field[...] = flow_sim.vorticity_field.copy()
+    ref_vorticity_divg_l2_norm = ref_flow_sim.get_vorticity_divergence_l2_norm()
     assert vorticity_divergence_l2_norm == ref_vorticity_divg_l2_norm

--- a/tests/test_simulator/test_flow/test_navier_stokes_flow_simulators.py
+++ b/tests/test_simulator/test_flow/test_navier_stokes_flow_simulators.py
@@ -1,0 +1,161 @@
+import numpy as np
+import pytest
+import sopht.simulator as sps
+import sopht.numeric.eulerian_grid_ops as spne
+import sopht.utils as spu
+
+
+@pytest.mark.parametrize("grid_size_x", [8, 16])
+@pytest.mark.parametrize("precision", ["single", "double"])
+@pytest.mark.parametrize("with_free_stream", [True, False])
+def test_navier_stokes_flow_sim_2d_with_forcing_timestep(
+    grid_size_x, precision, with_free_stream
+):
+    num_threads = 4
+    grid_dim = 2
+    x_range = 1.0
+    nu = 1.0
+    real_t = spu.get_real_t(precision)
+    grid_size = (grid_size_x,) * grid_dim
+    dx = real_t(x_range / grid_size_x)
+    dt = 2.0
+    free_stream_velocity = np.array([3.0, 4.0])
+    init_time = 1.0
+    flow_sim = sps.UnboundedNavierStokesFlowSimulator2D(
+        grid_size=grid_size,
+        x_range=x_range,
+        kinematic_viscosity=nu,
+        real_t=real_t,
+        num_threads=num_threads,
+        time=init_time,
+        with_forcing=True,
+        with_free_stream_flow=with_free_stream,
+    )
+    ref_time = init_time + dt
+    # initialise flow sim state (vorticity and forcing)
+    flow_sim.vorticity_field[...] = np.random.rand(
+        *flow_sim.vorticity_field.shape
+    ).astype(real_t)
+    flow_sim.velocity_field[...] = 0 * np.random.rand(
+        *flow_sim.velocity_field.shape
+    ).astype(real_t)
+    flow_sim.eul_grid_forcing_field[...] = np.random.rand(
+        *flow_sim.eul_grid_forcing_field.shape
+    ).astype(real_t)
+    ref_vorticity_field = flow_sim.vorticity_field.copy()
+    ref_velocity_field = flow_sim.velocity_field.copy()
+    ref_eul_grid_forcing_field = flow_sim.eul_grid_forcing_field.copy()
+    flow_sim.time_step(dt=dt, free_stream_velocity=free_stream_velocity)
+
+    # next we setup the reference timestep manually
+    # first we compile necessary kernels
+    diffusion_timestep = spne.gen_diffusion_timestep_euler_forward_pyst_kernel_2d(
+        real_t=real_t,
+        fixed_grid_size=grid_size,
+        num_threads=num_threads,
+    )
+    advection_timestep = (
+        spne.gen_advection_timestep_euler_forward_conservative_eno3_pyst_kernel_2d(
+            real_t=real_t,
+            fixed_grid_size=grid_size,
+            num_threads=num_threads,
+        )
+    )
+    grid_size_y, grid_size_x = grid_size
+    unbounded_poisson_solver = spne.UnboundedPoissonSolverPYFFTW2D(
+        grid_size_y=grid_size_y,
+        grid_size_x=grid_size_x,
+        x_range=x_range,
+        real_t=real_t,
+        num_threads=num_threads,
+    )
+    curl = spne.gen_outplane_field_curl_pyst_kernel_2d(
+        real_t=real_t,
+        num_threads=num_threads,
+        fixed_grid_size=grid_size,
+    )
+    penalise_field_towards_boundary = spne.gen_penalise_field_boundary_pyst_kernel_2d(
+        width=flow_sim.penalty_zone_width,
+        dx=dx,
+        x_grid_field=flow_sim.position_field[spu.VectorField.x_axis_idx()],
+        y_grid_field=flow_sim.position_field[spu.VectorField.y_axis_idx()],
+        real_t=real_t,
+        num_threads=num_threads,
+        fixed_grid_size=grid_size,
+    )
+    update_vorticity_from_velocity_forcing = (
+        spne.gen_update_vorticity_from_velocity_forcing_pyst_kernel_2d(
+            real_t=real_t,
+            fixed_grid_size=grid_size,
+            num_threads=num_threads,
+        )
+    )
+
+    # manually timestep
+    update_vorticity_from_velocity_forcing(
+        vorticity_field=ref_vorticity_field,
+        velocity_forcing_field=ref_eul_grid_forcing_field,
+        prefactor=real_t(dt / (2 * dx)),
+    )
+    flux_buffer = np.zeros(grid_size, dtype=real_t)
+    advection_timestep(
+        field=ref_vorticity_field,
+        advection_flux=flux_buffer,
+        velocity=ref_velocity_field,
+        dt_by_dx=real_t(dt / dx),
+    )
+    diffusion_timestep(
+        field=ref_vorticity_field,
+        diffusion_flux=flux_buffer,
+        nu_dt_by_dx2=real_t(nu * dt / dx / dx),
+    )
+    penalise_field_towards_boundary(field=ref_vorticity_field)
+    stream_func_field = np.zeros(grid_size, dtype=real_t)
+    unbounded_poisson_solver.solve(
+        solution_field=stream_func_field,
+        rhs_field=ref_vorticity_field,
+    )
+    curl(
+        curl=ref_velocity_field,
+        field=stream_func_field,
+        prefactor=real_t(0.5 / dx),
+    )
+    if with_free_stream:
+        ref_velocity_field[...] += free_stream_velocity.reshape((grid_dim, 1, 1))
+
+    assert flow_sim.time == ref_time
+    np.testing.assert_allclose(flow_sim.eul_grid_forcing_field, 0.0)
+    np.testing.assert_allclose(flow_sim.vorticity_field, ref_vorticity_field)
+    np.testing.assert_allclose(flow_sim.velocity_field, ref_velocity_field)
+
+
+@pytest.mark.parametrize("grid_size_x", [8, 16])
+@pytest.mark.parametrize("precision", ["single", "double"])
+def test_navier_stokes_flow_sim_2d_compute_stable_time_step(grid_size_x, precision):
+    num_threads = 4
+    grid_dim = 2
+    x_range = 1.0
+    nu = 1e-2
+    real_t = spu.get_real_t(precision)
+    grid_size = (grid_size_x,) * grid_dim
+    dx = real_t(x_range / grid_size_x)
+    cfl = 0.2
+    flow_sim = sps.UnboundedNavierStokesFlowSimulator2D(
+        grid_size=grid_size,
+        x_range=x_range,
+        cfl=cfl,
+        kinematic_viscosity=nu,
+        real_t=real_t,
+        num_threads=num_threads,
+    )
+    flow_sim.velocity_field[...] = 2.0
+    dt_prefac = 0.5
+    sim_dt = flow_sim.compute_stable_time_step(dt_prefac=dt_prefac)
+    # next compute reference value
+    tol = 10 * np.finfo(real_t).eps
+    advection_limit_dt = (
+        cfl * dx / (grid_dim * 2.0 + tol)
+    )  # max(sum(abs(velocity_field)))
+    diffusion_limit_dt = 0.9 * dx**2 / (2 * grid_dim) / nu
+    ref_dt = dt_prefac * min(advection_limit_dt, diffusion_limit_dt)
+    assert ref_dt == sim_dt

--- a/tests/test_simulator/test_flow/test_navier_stokes_flow_simulators.py
+++ b/tests/test_simulator/test_flow/test_navier_stokes_flow_simulators.py
@@ -131,7 +131,7 @@ def test_navier_stokes_flow_sim_2d_with_forcing_timestep(
 
 @pytest.mark.parametrize("grid_size_x", [8, 16])
 @pytest.mark.parametrize("precision", ["single", "double"])
-def test_navier_stokes_flow_sim_2d_compute_stable_time_step(grid_size_x, precision):
+def test_navier_stokes_flow_sim_2d_compute_stable_timestep(grid_size_x, precision):
     num_threads = 4
     grid_dim = 2
     x_range = 1.0
@@ -150,7 +150,7 @@ def test_navier_stokes_flow_sim_2d_compute_stable_time_step(grid_size_x, precisi
     )
     flow_sim.velocity_field[...] = 2.0
     dt_prefac = 0.5
-    sim_dt = flow_sim.compute_stable_time_step(dt_prefac=dt_prefac)
+    sim_dt = flow_sim.compute_stable_timestep(dt_prefac=dt_prefac)
     # next compute reference value
     tol = 10 * np.finfo(real_t).eps
     advection_limit_dt = (
@@ -159,3 +159,229 @@ def test_navier_stokes_flow_sim_2d_compute_stable_time_step(grid_size_x, precisi
     diffusion_limit_dt = 0.9 * dx**2 / (2 * grid_dim) / nu
     ref_dt = dt_prefac * min(advection_limit_dt, diffusion_limit_dt)
     assert ref_dt == sim_dt
+
+
+@pytest.mark.parametrize("grid_size_x", [4, 8])
+@pytest.mark.parametrize("precision", ["single", "double"])
+@pytest.mark.parametrize("with_free_stream", [True, False])
+@pytest.mark.parametrize("filter_vorticity", [True, False])
+def test_navier_stokes_flow_sim_3d_with_forcing_timestep(
+    grid_size_x,
+    precision,
+    with_free_stream,
+    filter_vorticity,
+):
+    num_threads = 4
+    grid_dim = 3
+    x_range = 1.0
+    nu = 1e-2
+    real_t = spu.get_real_t(precision)
+    grid_size = (grid_size_x,) * grid_dim
+    dx = real_t(x_range / grid_size_x)
+    dt = 2.0
+    free_stream_velocity = np.array([3.0, 4.0, 5.0])
+    init_time = 1.0
+    filter_type = "convolution"
+    filter_order = 2
+    flow_sim = sps.UnboundedNavierStokesFlowSimulator3D(
+        grid_size=grid_size,
+        x_range=x_range,
+        kinematic_viscosity=nu,
+        real_t=real_t,
+        num_threads=num_threads,
+        time=init_time,
+        with_forcing=True,
+        with_free_stream_flow=with_free_stream,
+        filter_vorticity=filter_vorticity,
+        filter_setting_dict={"type": filter_type, "order": filter_order},
+    )
+    ref_time = init_time + dt
+    # initialise flow sim state (vorticity and forcing)
+    flow_sim.vorticity_field[...] = np.random.rand(
+        *flow_sim.vorticity_field.shape
+    ).astype(real_t)
+    flow_sim.velocity_field[...] = 0 * np.random.rand(
+        *flow_sim.velocity_field.shape
+    ).astype(real_t)
+    flow_sim.eul_grid_forcing_field[...] = np.random.rand(
+        *flow_sim.eul_grid_forcing_field.shape
+    ).astype(real_t)
+    ref_vorticity_field = flow_sim.vorticity_field.copy()
+    ref_velocity_field = flow_sim.velocity_field.copy()
+    ref_eul_grid_forcing_field = flow_sim.eul_grid_forcing_field.copy()
+    flow_sim.time_step(dt=dt, free_stream_velocity=free_stream_velocity)
+    # next we setup the reference timestep manually
+    # first we compile necessary kernels
+    diffusion_timestep = spne.gen_diffusion_timestep_euler_forward_pyst_kernel_3d(
+        real_t=real_t,
+        fixed_grid_size=grid_size,
+        num_threads=num_threads,
+        field_type="vector",
+    )
+    elementwise_cross_product = spne.gen_elementwise_cross_product_pyst_kernel_3d(
+        real_t=real_t,
+        num_threads=num_threads,
+        fixed_grid_size=grid_size,
+    )
+    grid_size_z, grid_size_y, grid_size_x = grid_size
+    unbounded_poisson_solver = spne.UnboundedPoissonSolverPYFFTW3D(
+        grid_size_z=grid_size_z,
+        grid_size_y=grid_size_y,
+        grid_size_x=grid_size_x,
+        x_range=x_range,
+        real_t=real_t,
+        num_threads=num_threads,
+    )
+    curl = spne.gen_curl_pyst_kernel_3d(
+        real_t=real_t,
+        num_threads=num_threads,
+        fixed_grid_size=grid_size,
+    )
+    penalise_field_towards_boundary = spne.gen_penalise_field_boundary_pyst_kernel_3d(
+        width=flow_sim.penalty_zone_width,
+        dx=dx,
+        x_grid_field=flow_sim.position_field[spu.VectorField.x_axis_idx()],
+        y_grid_field=flow_sim.position_field[spu.VectorField.y_axis_idx()],
+        z_grid_field=flow_sim.position_field[spu.VectorField.z_axis_idx()],
+        real_t=real_t,
+        num_threads=num_threads,
+        fixed_grid_size=grid_size,
+        field_type="vector",
+    )
+    update_vorticity_from_velocity_forcing = (
+        spne.gen_update_vorticity_from_velocity_forcing_pyst_kernel_3d(
+            real_t=real_t,
+            fixed_grid_size=grid_size,
+            num_threads=num_threads,
+        )
+    )
+    if filter_vorticity:
+        filter_vector_field = spne.gen_laplacian_filter_kernel_3d(
+            filter_flux_buffer=np.zeros_like(ref_vorticity_field[0]),
+            field_buffer=np.zeros_like(ref_vorticity_field[0]),
+            real_t=real_t,
+            num_threads=num_threads,
+            fixed_grid_size=grid_size,
+            field_type="vector",
+            filter_order=filter_order,
+            filter_type=filter_type,
+        )
+    else:
+
+        def filter_vector_field(vector_field):
+            ...
+
+    # manually timestep
+    update_vorticity_from_velocity_forcing(
+        vorticity_field=ref_vorticity_field,
+        velocity_forcing_field=ref_eul_grid_forcing_field,
+        prefactor=real_t(dt / (2 * dx)),
+    )
+    velocity_cross_vorticity = np.zeros_like(ref_vorticity_field)
+    elementwise_cross_product(
+        result_field=velocity_cross_vorticity,
+        field_1=ref_velocity_field,
+        field_2=ref_vorticity_field,
+    )
+    update_vorticity_from_velocity_forcing(
+        vorticity_field=ref_vorticity_field,
+        velocity_forcing_field=velocity_cross_vorticity,
+        prefactor=real_t(dt / (2 * dx)),
+    )
+    flux_buffer = np.zeros(grid_size, dtype=real_t)
+    diffusion_timestep(
+        vector_field=ref_vorticity_field,
+        diffusion_flux=flux_buffer,
+        nu_dt_by_dx2=real_t(nu * dt / dx / dx),
+    )
+    filter_vector_field(vector_field=ref_vorticity_field)
+    penalise_field_towards_boundary(vector_field=ref_vorticity_field)
+    stream_func_field = np.zeros_like(ref_vorticity_field)
+    unbounded_poisson_solver.vector_field_solve(
+        solution_vector_field=stream_func_field,
+        rhs_vector_field=ref_vorticity_field,
+    )
+    curl(
+        curl=ref_velocity_field,
+        field=stream_func_field,
+        prefactor=real_t(0.5 / dx),
+    )
+    if with_free_stream:
+        ref_velocity_field[...] += free_stream_velocity.reshape((grid_dim, 1, 1, 1))
+
+    assert flow_sim.time == ref_time
+    np.testing.assert_allclose(flow_sim.eul_grid_forcing_field, 0.0)
+    np.testing.assert_allclose(flow_sim.vorticity_field, ref_vorticity_field)
+    np.testing.assert_allclose(flow_sim.velocity_field, ref_velocity_field)
+
+
+@pytest.mark.parametrize("grid_size_x", [4, 8])
+@pytest.mark.parametrize("precision", ["single", "double"])
+def test_navier_stokes_flow_sim_3d_compute_stable_timestep(grid_size_x, precision):
+    num_threads = 4
+    grid_dim = 3
+    x_range = 1.0
+    nu = 1e-2
+    real_t = spu.get_real_t(precision)
+    grid_size = (grid_size_x,) * grid_dim
+    dx = real_t(x_range / grid_size_x)
+    cfl = 0.2
+    flow_sim = sps.UnboundedNavierStokesFlowSimulator3D(
+        grid_size=grid_size,
+        x_range=x_range,
+        kinematic_viscosity=nu,
+        real_t=real_t,
+        num_threads=num_threads,
+        cfl=cfl,
+    )
+    flow_sim.velocity_field[...] = 2.0
+    dt_prefac = 0.5
+    sim_dt = flow_sim.compute_stable_timestep(dt_prefac=dt_prefac)
+    # next compute reference value
+    tol = 10 * np.finfo(real_t).eps
+    advection_limit_dt = (
+        cfl * dx / (grid_dim * 2.0 + tol)
+    )  # max(sum(abs(velocity_field)))
+    diffusion_limit_dt = 0.9 * dx**2 / (2 * grid_dim) / nu
+    ref_dt = dt_prefac * min(advection_limit_dt, diffusion_limit_dt)
+    assert ref_dt == sim_dt
+
+
+@pytest.mark.parametrize("grid_size_x", [4, 8])
+@pytest.mark.parametrize("precision", ["single", "double"])
+def test_navier_stokes_flow_sim_3d_get_vorticity_divergence_l2_norm(
+    grid_size_x, precision
+):
+    num_threads = 4
+    grid_dim = 3
+    x_range = 1.0
+    nu = 1e-2
+    real_t = spu.get_real_t(precision)
+    grid_size = (grid_size_x,) * grid_dim
+    dx = real_t(x_range / grid_size_x)
+    flow_sim = sps.UnboundedNavierStokesFlowSimulator3D(
+        grid_size=grid_size,
+        x_range=x_range,
+        kinematic_viscosity=nu,
+        real_t=real_t,
+        num_threads=num_threads,
+    )
+    flow_sim.vorticity_field[...] = np.random.rand(grid_dim, *grid_size)
+    vorticity_divergence_l2_norm = flow_sim.get_vorticity_divergence_l2_norm()
+
+    # compute manually
+    compute_divergence = spne.gen_divergence_pyst_kernel_3d(
+        real_t=real_t,
+        fixed_grid_size=grid_size,
+        num_threads=num_threads,
+    )
+    divergence_field = np.zeros_like(flow_sim.vorticity_field[0])
+    compute_divergence(
+        divergence=divergence_field,
+        field=flow_sim.vorticity_field,
+        inv_dx=(1.0 / dx),
+    )
+    ref_vorticity_divg_l2_norm = np.linalg.norm(divergence_field) * dx ** (
+        grid_dim / 2.0
+    )
+    assert vorticity_divergence_l2_norm == ref_vorticity_divg_l2_norm

--- a/tests/test_simulator/test_flow/test_passive_transport_flow_simulators.py
+++ b/tests/test_simulator/test_flow/test_passive_transport_flow_simulators.py
@@ -1,0 +1,131 @@
+import numpy as np
+import pytest
+import sopht.utils as spu
+import sopht.simulator as sps
+import sopht.numeric.eulerian_grid_ops as spne
+
+
+@pytest.mark.parametrize("grid_dim", [2, 3])
+@pytest.mark.parametrize("grid_size_x", [4, 8])
+@pytest.mark.parametrize("precision", ["single", "double"])
+@pytest.mark.parametrize("field_type", ["scalar", "vector"])
+def test_passive_transport_flow_simulator_time_step(
+    grid_dim,
+    field_type,
+    grid_size_x,
+    precision,
+):
+    num_threads = 4
+    x_range = 1.0
+    nu = 1e-2
+    real_t = spu.get_real_t(precision)
+    grid_size = (grid_size_x,) * grid_dim
+    dx = real_t(x_range / grid_size_x)
+    dt = 2.0
+    init_time = 1.0
+    # TODO support this option in future
+    if grid_dim == 2 and field_type == "vector":
+        return
+    flow_sim = sps.PassiveTransportFlowSimulator(
+        kinematic_viscosity=nu,
+        grid_dim=grid_dim,
+        grid_size=grid_size,
+        x_range=x_range,
+        real_t=real_t,
+        num_threads=num_threads,
+        time=init_time,
+        field_type=field_type,
+    )
+    ref_time = init_time + dt
+    # initialise flow sim state (passive fields)
+    flow_sim.velocity_field[...] = np.random.rand(
+        *flow_sim.velocity_field.shape
+    ).astype(real_t)
+    flow_sim.primary_field[...] = np.random.rand(*flow_sim.primary_field.shape).astype(
+        real_t
+    )
+    ref_primary_field = flow_sim.primary_field.copy()
+    flow_sim.time_step(dt=dt)
+
+    # next we setup the reference timestep manually
+    # first we compile necessary kernels
+    advection_timestep = None
+    diffusion_timestep = None
+    match grid_dim:
+        case 2:
+            diffusion_timestep = (
+                spne.gen_diffusion_timestep_euler_forward_pyst_kernel_2d(
+                    real_t=real_t,
+                    fixed_grid_size=grid_size,
+                    num_threads=num_threads,
+                )
+            )
+            advection_timestep = spne.gen_advection_timestep_euler_forward_conservative_eno3_pyst_kernel_2d(
+                real_t=real_t,
+                fixed_grid_size=grid_size,
+                num_threads=num_threads,
+            )
+        case 3:
+            diffusion_timestep = (
+                spne.gen_diffusion_timestep_euler_forward_pyst_kernel_3d(
+                    real_t=real_t,
+                    fixed_grid_size=grid_size,
+                    num_threads=num_threads,
+                    field_type=field_type,
+                )
+            )
+            advection_timestep = spne.gen_advection_timestep_euler_forward_conservative_eno3_pyst_kernel_3d(
+                real_t=real_t,
+                fixed_grid_size=grid_size,
+                num_threads=num_threads,
+                field_type=field_type,
+            )
+    # manually timestep
+    advection_timestep(
+        ref_primary_field,
+        advection_flux=np.zeros_like(flow_sim.buffer_scalar_field),
+        velocity=flow_sim.velocity_field,
+        dt_by_dx=real_t(dt / dx),
+    )
+    diffusion_timestep(
+        ref_primary_field,
+        diffusion_flux=np.zeros_like(flow_sim.buffer_scalar_field),
+        nu_dt_by_dx2=real_t(nu * dt / dx / dx),
+    )
+    assert flow_sim.time == ref_time
+    np.testing.assert_allclose(flow_sim.primary_field, ref_primary_field)
+
+
+@pytest.mark.parametrize("grid_dim", [2, 3])
+@pytest.mark.parametrize("grid_size_x", [4, 8])
+@pytest.mark.parametrize("precision", ["single", "double"])
+def test_passive_transport_flow_sim_compute_stable_time_step(
+    grid_dim, grid_size_x, precision
+):
+    num_threads = 4
+    x_range = 1.0
+    nu = 1e-2
+    real_t = spu.get_real_t(precision)
+    grid_size = (grid_size_x,) * grid_dim
+    dx = real_t(x_range / grid_size_x)
+    cfl = 0.2
+    flow_sim = sps.PassiveTransportFlowSimulator(
+        kinematic_viscosity=nu,
+        cfl=cfl,
+        grid_dim=grid_dim,
+        grid_size=grid_size,
+        x_range=x_range,
+        real_t=real_t,
+        num_threads=num_threads,
+    )
+    flow_sim.velocity_field[...] = 2.0
+    dt_prefac = 0.5
+    sim_dt = flow_sim.compute_stable_time_step(dt_prefac=dt_prefac)
+    # next compute reference value
+    tol = 10 * np.finfo(real_t).eps
+    advection_limit_dt = (
+        cfl * dx / (grid_dim * 2.0 + tol)
+    )  # max(sum(abs(velocity_field)))
+    diffusion_limit_dt = 0.9 * dx**2 / (2 * grid_dim) / nu
+    ref_dt = dt_prefac * min(advection_limit_dt, diffusion_limit_dt)
+    assert ref_dt == sim_dt

--- a/tests/test_simulator/test_flow/test_passive_transport_flow_simulators.py
+++ b/tests/test_simulator/test_flow/test_passive_transport_flow_simulators.py
@@ -99,7 +99,7 @@ def test_passive_transport_flow_simulator_time_step(
 @pytest.mark.parametrize("grid_dim", [2, 3])
 @pytest.mark.parametrize("grid_size_x", [4, 8])
 @pytest.mark.parametrize("precision", ["single", "double"])
-def test_passive_transport_flow_sim_compute_stable_time_step(
+def test_passive_transport_flow_sim_compute_stable_timestep(
     grid_dim, grid_size_x, precision
 ):
     num_threads = 4
@@ -120,7 +120,7 @@ def test_passive_transport_flow_sim_compute_stable_time_step(
     )
     flow_sim.velocity_field[...] = 2.0
     dt_prefac = 0.5
-    sim_dt = flow_sim.compute_stable_time_step(dt_prefac=dt_prefac)
+    sim_dt = flow_sim.compute_stable_timestep(dt_prefac=dt_prefac)
     # next compute reference value
     tol = 10 * np.finfo(real_t).eps
     advection_limit_dt = (


### PR DESCRIPTION
Fixes #103. Refactoring of flow simulator class to:
1. Reduce convoluted conditional compilation of kernels inside the simulator.
2. Provide a proper interface via the base class `FlowSimulator`
3. Separates conceptually different simulators (passive transport vs. navier stokes) into different derived simulators

@armantekinalp additionally, the older `UnboundedFlowSimulator` still works, which will now forward the arguments and return the appropriate simulator (which has been tested).