### PR TITLE
138 virtual boundary method for scalar fields

### DIFF
--- a/sopht/numeric/eulerian_grid_ops/stencil_ops_2d/elementwise_ops_2d.py
+++ b/sopht/numeric/eulerian_grid_ops/stencil_ops_2d/elementwise_ops_2d.py
@@ -83,7 +83,11 @@ def gen_set_fixed_val_pyst_kernel_2d(
     ).compile()
     match field_type:
         case "scalar":
-            return set_fixed_val_pyst_kernel_2d
+
+            def scalar_field_set_fixed_val_pyst_kernel_2d(field, fixed_val):
+                set_fixed_val_pyst_kernel_2d(field=field, fixed_val=fixed_val)
+
+            return scalar_field_set_fixed_val_pyst_kernel_2d
         case "vector":
             x_axis_idx = spu.VectorField.x_axis_idx()
             y_axis_idx = spu.VectorField.y_axis_idx()

--- a/sopht/numeric/eulerian_grid_ops/stencil_ops_3d/elementwise_ops_3d.py
+++ b/sopht/numeric/eulerian_grid_ops/stencil_ops_3d/elementwise_ops_3d.py
@@ -83,7 +83,11 @@ def gen_set_fixed_val_pyst_kernel_3d(
     ).compile()
     match field_type:
         case "scalar":
-            return set_fixed_val_pyst_kernel_3d
+
+            def scalar_field_set_fixed_val_pyst_kernel_3d(field, fixed_val):
+                set_fixed_val_pyst_kernel_3d(field=field, fixed_val=fixed_val)
+
+            return scalar_field_set_fixed_val_pyst_kernel_3d
         case "vector":
             x_axis_idx = spu.VectorField.x_axis_idx()
             y_axis_idx = spu.VectorField.y_axis_idx()

--- a/sopht/numeric/immersed_boundary_ops/VirtualBoundaryForcing.py
+++ b/sopht/numeric/immersed_boundary_ops/VirtualBoundaryForcing.py
@@ -1,6 +1,6 @@
 """Virtual boundary forcing for flow-body feedback."""
 from numba import njit
-
+from typing import Literal
 import numpy as np
 
 from sopht.numeric.eulerian_grid_ops.stencil_ops_2d.elementwise_ops_2d import (
@@ -39,6 +39,7 @@ class VirtualBoundaryForcing:
         enable_eul_grid_forcing_reset=True,
         num_threads=False,
         start_time=0.0,
+        field_type: Literal["scalar", "vector"] = "vector",
     ):
         """Class initialiser.
 
@@ -59,13 +60,15 @@ class VirtualBoundaryForcing:
         with resetting of eul_grid_forcing_field
         num_threads: number of threads (only for the resetting function)
         start_time: start time of the forcing
-
+        field_type: This can be a vector like velocity as we use traditionally in p-IBM, or scalar like temperature.
         """
         assert grid_dim == 2 or grid_dim == 3, "Invalid grid dimensions"
         self.grid_dim = grid_dim
         self.virtual_boundary_stiffness_coeff = virtual_boundary_stiffness_coeff
         self.virtual_boundary_damping_coeff = virtual_boundary_damping_coeff
         self.time = start_time
+        assert field_type == "scalar" or field_type == "vector", "Invalid field type"
+        self.field_type = field_type
 
         # these are rather invariant hence pushed to fixed kwargs
         if eul_grid_coord_shift is None:
@@ -85,9 +88,13 @@ class VirtualBoundaryForcing:
         )
         interp_weights_shape = (2 * interp_kernel_width,) * grid_dim + (num_lag_nodes,)
         self.interp_weights = np.empty(interp_weights_shape, dtype=real_t)
-        self.lag_grid_flow_velocity_field = np.zeros(
-            (grid_dim, num_lag_nodes), dtype=real_t
-        )
+
+        if self.field_type == "scalar":
+            self.lag_grid_flow_velocity_field = np.zeros((num_lag_nodes), dtype=real_t)
+        else:
+            self.lag_grid_flow_velocity_field = np.zeros(
+                (grid_dim, num_lag_nodes), dtype=real_t
+            )
         self.lag_grid_position_mismatch_field = np.zeros_like(
             self.lag_grid_flow_velocity_field
         )
@@ -98,6 +105,10 @@ class VirtualBoundaryForcing:
             self.lag_grid_velocity_mismatch_field
         )
 
+        self.fixed_vals_eul_grid_forcing = (
+            [0] * self.grid_dim if self.field_type == "vector" else 0
+        )
+
         if grid_dim == 2:
             self.eul_lag_grid_communicator = EulerianLagrangianGridCommunicator2D(
                 dx=dx,
@@ -105,7 +116,7 @@ class VirtualBoundaryForcing:
                 num_lag_nodes=num_lag_nodes,
                 interp_kernel_width=interp_kernel_width,
                 real_t=real_t,
-                n_components=grid_dim,
+                n_components=grid_dim if self.field_type == "vector" else 1,
             )
         elif grid_dim == 3:
             self.eul_lag_grid_communicator = EulerianLagrangianGridCommunicator3D(
@@ -114,22 +125,24 @@ class VirtualBoundaryForcing:
                 num_lag_nodes=num_lag_nodes,
                 interp_kernel_width=interp_kernel_width,
                 real_t=real_t,
-                n_components=grid_dim,
+                n_components=grid_dim if self.field_type == "vector" else 1,
             )
 
         if enable_eul_grid_forcing_reset:
             if grid_dim == 2:
-                self.set_eul_grid_vector_field = gen_set_fixed_val_pyst_kernel_2d(
+                self.set_eul_grid_forcing_field = gen_set_fixed_val_pyst_kernel_2d(
                     real_t=real_t,
                     num_threads=num_threads,
-                    field_type="vector",
+                    field_type=self.field_type,
+                    # field_type="vector",
                 )
 
             elif grid_dim == 3:
-                self.set_eul_grid_vector_field = gen_set_fixed_val_pyst_kernel_3d(
+                self.set_eul_grid_forcing_field = gen_set_fixed_val_pyst_kernel_3d(
                     real_t=real_t,
                     num_threads=num_threads,
-                    field_type="vector",
+                    field_type=self.field_type,
+                    # field_type="vector",
                 )
             self.compute_interaction_forcing = (
                 self.compute_interaction_force_on_eul_and_lag_grid_with_eul_grid_forcing_reset
@@ -273,8 +286,8 @@ class VirtualBoundaryForcing:
 
         Resets eul_grid_forcing_field.
         """
-        self.set_eul_grid_vector_field(
-            vector_field=eul_grid_forcing_field, fixed_vals=([0] * self.grid_dim)
+        self.set_eul_grid_forcing_field(
+            eul_grid_forcing_field, self.fixed_vals_eul_grid_forcing
         )
         self.compute_interaction_force_on_eul_and_lag_grid(
             eul_grid_forcing_field,

--- a/sopht/simulator/immersed_body/immersed_body_flow_interaction.py
+++ b/sopht/simulator/immersed_body/immersed_body_flow_interaction.py
@@ -4,7 +4,7 @@ from sopht.numeric.immersed_boundary_ops import VirtualBoundaryForcing
 from .immersed_body_forcing_grid import (
     ImmersedBodyForcingGrid,
 )
-from typing import Type, Optional
+from typing import Type, Optional, Literal
 
 
 class ImmersedBodyFlowInteraction(VirtualBoundaryForcing):
@@ -27,6 +27,7 @@ class ImmersedBodyFlowInteraction(VirtualBoundaryForcing):
         enable_eul_grid_forcing_reset: bool = False,
         num_threads: int | bool = False,
         start_time: float = 0.0,
+        field_type: Literal["scalar", "vector"] = "vector",
         **forcing_grid_kwargs,
     ) -> None:
         """Class initialiser."""
@@ -36,6 +37,12 @@ class ImmersedBodyFlowInteraction(VirtualBoundaryForcing):
         self.forcing_grid = forcing_grid_cls(
             grid_dim=grid_dim,
             **forcing_grid_kwargs,
+        )
+        assert self.forcing_grid.velocity_field.ndim == (
+            2 if field_type == "vector" else 1
+        ), (
+            f"Forcing grid {forcing_grid_cls.__name__}"
+            f" does not support field type {field_type}"
         )
         # these hold references to Eulerian fields
         self.eul_grid_forcing_field = eul_grid_forcing_field.view()
@@ -95,6 +102,7 @@ class ImmersedBodyFlowInteraction(VirtualBoundaryForcing):
             enable_eul_grid_forcing_reset,
             num_threads,
             start_time,
+            field_type,
         )
 
     def compute_interaction_on_lag_grid(self) -> None:

--- a/sopht/simulator/immersed_body/rigid_body/__init__.py
+++ b/sopht/simulator/immersed_body/rigid_body/__init__.py
@@ -5,6 +5,7 @@ from .rigid_body_forcing_grids import (
     OpenEndCircularCylinderForcingGrid,
     SphereForcingGrid,
     RectangularPlaneForcingGrid,
+    CircularCylinderConstantTemperatureForcingGrid,
 )
 from .rigid_body_flow_interaction import RigidBodyFlowInteraction
 from .derived_rigid_bodies import RectangularPlane

--- a/sopht/simulator/immersed_body/rigid_body/rigid_body_flow_interaction.py
+++ b/sopht/simulator/immersed_body/rigid_body/rigid_body_flow_interaction.py
@@ -4,7 +4,7 @@ from sopht.simulator.immersed_body import (
     ImmersedBodyForcingGrid,
     ImmersedBodyFlowInteraction,
 )
-from typing import Type, Optional
+from typing import Type, Optional, Literal
 
 
 class RigidBodyFlowInteraction(ImmersedBodyFlowInteraction):
@@ -26,6 +26,7 @@ class RigidBodyFlowInteraction(ImmersedBodyFlowInteraction):
         enable_eul_grid_forcing_reset: bool = False,
         num_threads: int | bool = False,
         start_time: float = 0.0,
+        field_type: Literal["scalar", "vector"] = "vector",
         **forcing_grid_kwargs,
     ) -> None:
         """Class initialiser."""
@@ -50,5 +51,6 @@ class RigidBodyFlowInteraction(ImmersedBodyFlowInteraction):
             enable_eul_grid_forcing_reset,
             num_threads,
             start_time,
+            field_type,
             **forcing_grid_kwargs,
         )

--- a/sopht/simulator/immersed_body/rigid_body/rigid_body_forcing_grids.py
+++ b/sopht/simulator/immersed_body/rigid_body/rigid_body_forcing_grids.py
@@ -114,6 +114,45 @@ class CircularCylinderForcingGrid(TwoDimensionalCylinderForcingGrid):
         return self.cylinder.radius * (2.0 * np.pi / self.num_lag_nodes)
 
 
+class CircularCylinderConstantTemperatureForcingGrid(CircularCylinderForcingGrid):
+    """Class for temperature forcing grid of a 2D circular cylinder with cross-section
+    in XY plane. Here cylinder is always at constant temperature.
+
+    """
+
+    def __init__(
+        self,
+        grid_dim: int,
+        rigid_body: ea.Cylinder,
+        num_forcing_points: int,
+        cylinder_temperature: float,
+    ) -> None:
+        super().__init__(
+            grid_dim=grid_dim,
+            num_forcing_points=num_forcing_points,
+            rigid_body=rigid_body,
+        )
+        # Here velocity field represents the cylinder temperature.
+        self.velocity_field = cylinder_temperature * np.ones(num_forcing_points)
+        # to ensure position/velocity are consistent during initialisation
+        self.compute_lag_grid_position_field()
+        self.compute_lag_grid_velocity_field()
+
+    def compute_lag_grid_velocity_field(self) -> None:
+        # Cylinder is not heating up or cooling down. Temperature is constant.
+        # Thus, velocity field is always constant, and we don't need to compute.
+        pass
+
+    def transfer_forcing_from_grid_to_body(
+        self,
+        body_flow_forces: np.ndarray,
+        body_flow_torques: np.ndarray,
+        lag_grid_forcing_field: np.ndarray,
+    ) -> None:
+        # Cylinder is not heating up or cooling down. Temperature is constant, so no feedback to the cylinder.
+        pass
+
+
 SupportedRigidBody3D = Union[ea.Cylinder, ea.Sphere, RectangularPlane]
 
 

--- a/tests/test_numeric/test_immersed_boundary_ops/test_virtual_boundary_forcing.py
+++ b/tests/test_numeric/test_immersed_boundary_ops/test_virtual_boundary_forcing.py
@@ -6,12 +6,19 @@ import pytest
 
 from sopht.numeric.immersed_boundary_ops import VirtualBoundaryForcing
 from sopht.utils.precision import get_real_t, get_test_tol
+from typing import Literal
 
 
 class MockVirtualBoundaryForcingSolution:
     """Mock solution test class for virtual boundary forcing."""
 
-    def __init__(self, grid_size, grid_dim=2, precision="single"):
+    def __init__(
+        self,
+        grid_size,
+        grid_dim=2,
+        precision="single",
+        field_type: Literal["scalar", "vector"] = "vector",
+    ):
         """Class initialiser."""
         real_t = get_real_t(precision)
         self.test_tol = get_test_tol(precision)
@@ -24,19 +31,31 @@ class MockVirtualBoundaryForcingSolution:
         self.interp_kernel_width = 2
         self.grid_dim = grid_dim
         self.grid_size = grid_size
+        self.field_type = field_type
         self.time = 0.0
 
     def compute_interaction_step_solution(
         self,
     ):
         """Compute solution fields necessary for interaction step."""
-        eul_grid_velocity_shape = (self.grid_dim,) + (self.grid_size,) * self.grid_dim
+
+        if self.field_type == "scalar":
+            eul_grid_velocity_shape = (self.grid_size,) * self.grid_dim
+            self.lag_grid_velocity_field = self.real_t(2.0) * np.ones(
+                (self.num_lag_nodes), dtype=self.real_t
+            )
+        else:  # vector
+            eul_grid_velocity_shape = (self.grid_dim,) + (
+                self.grid_size,
+            ) * self.grid_dim
+            self.lag_grid_velocity_field = self.real_t(2.0) * np.ones(
+                (self.grid_dim, self.num_lag_nodes), dtype=self.real_t
+            )
+
         self.eul_grid_velocity_field = self.real_t(5.0) * np.ones(
             eul_grid_velocity_shape, dtype=self.real_t
         )
-        self.lag_grid_velocity_field = self.real_t(2.0) * np.ones(
-            (self.grid_dim, self.num_lag_nodes), dtype=self.real_t
-        )
+
         self.nearest_eul_grid_index_to_lag_grid = np.empty(
             (self.grid_dim, self.num_lag_nodes), dtype=int
         )
@@ -50,9 +69,14 @@ class MockVirtualBoundaryForcingSolution:
         )
 
         # interaction step solution computation
-        self.lag_grid_flow_velocity_field = self.real_t(5.0) * np.ones(
-            (self.grid_dim, self.num_lag_nodes), dtype=self.real_t
-        )
+        if self.field_type == "scalar":
+            self.lag_grid_flow_velocity_field = self.real_t(5.0) * np.ones(
+                (self.num_lag_nodes), dtype=self.real_t
+            )
+        else:
+            self.lag_grid_flow_velocity_field = self.real_t(5.0) * np.ones(
+                (self.grid_dim, self.num_lag_nodes), dtype=self.real_t
+            )
         self.lag_grid_velocity_mismatch_field = (
             self.lag_grid_flow_velocity_field - self.lag_grid_velocity_field
         )
@@ -116,11 +140,15 @@ class MockVirtualBoundaryForcingSolution:
 @pytest.mark.parametrize("precision", ["single", "double"])
 @pytest.mark.parametrize("grid_dim", [2, 3])
 @pytest.mark.parametrize("n_values", [16])
-def test_virtual_boundary_forcing_init(grid_dim, n_values, precision):
+@pytest.mark.parametrize("field_type", ["scalar", "vector"])
+def test_virtual_boundary_forcing_init(
+    grid_dim, n_values, precision, field_type: Literal["scalar", "vector"]
+):
     mock_soln = MockVirtualBoundaryForcingSolution(
         grid_size=n_values,
         grid_dim=grid_dim,
         precision=precision,
+        field_type=field_type,
     )
     virtual_boundary_forcing = VirtualBoundaryForcing(
         virtual_boundary_stiffness_coeff=mock_soln.virtual_boundary_stiffness_coeff,
@@ -130,6 +158,7 @@ def test_virtual_boundary_forcing_init(grid_dim, n_values, precision):
         num_lag_nodes=mock_soln.num_lag_nodes,
         real_t=mock_soln.real_t,
         start_time=mock_soln.time,
+        field_type=field_type,
     )
 
     assert virtual_boundary_forcing.time == mock_soln.time
@@ -173,29 +202,45 @@ def test_virtual_boundary_forcing_init(grid_dim, n_values, precision):
             2 * mock_soln.interp_kernel_width,
             mock_soln.num_lag_nodes,
         )
-    assert virtual_boundary_forcing.lag_grid_flow_velocity_field.shape == (
-        grid_dim,
-        mock_soln.num_lag_nodes,
-    )
-    assert virtual_boundary_forcing.lag_grid_velocity_mismatch_field.shape == (
-        grid_dim,
-        mock_soln.num_lag_nodes,
-    )
-    assert virtual_boundary_forcing.lag_grid_position_mismatch_field.shape == (
-        grid_dim,
-        mock_soln.num_lag_nodes,
-    )
+
+    if field_type == "scalar":
+        assert virtual_boundary_forcing.lag_grid_flow_velocity_field.shape == (
+            mock_soln.num_lag_nodes,
+        )
+        assert virtual_boundary_forcing.lag_grid_velocity_mismatch_field.shape == (
+            mock_soln.num_lag_nodes,
+        )
+        assert virtual_boundary_forcing.lag_grid_position_mismatch_field.shape == (
+            mock_soln.num_lag_nodes,
+        )
+    else:
+        assert virtual_boundary_forcing.lag_grid_flow_velocity_field.shape == (
+            grid_dim,
+            mock_soln.num_lag_nodes,
+        )
+        assert virtual_boundary_forcing.lag_grid_velocity_mismatch_field.shape == (
+            grid_dim,
+            mock_soln.num_lag_nodes,
+        )
+        assert virtual_boundary_forcing.lag_grid_position_mismatch_field.shape == (
+            grid_dim,
+            mock_soln.num_lag_nodes,
+        )
 
 
 @pytest.mark.parametrize("precision", ["single", "double"])
 @pytest.mark.parametrize("grid_dim", [2, 3])
 @pytest.mark.parametrize("n_values", [16])
-def test_compute_lag_grid_velocity_mismatch_field(grid_dim, n_values, precision):
+@pytest.mark.parametrize("field_type", ["scalar", "vector"])
+def test_compute_lag_grid_velocity_mismatch_field(
+    grid_dim, n_values, precision, field_type: Literal["scalar", "vector"]
+):
     real_t = get_real_t(precision)
     mock_soln = MockVirtualBoundaryForcingSolution(
         grid_size=n_values,
         grid_dim=grid_dim,
         precision=precision,
+        field_type=field_type,
     )
     virtual_boundary_forcing = VirtualBoundaryForcing(
         virtual_boundary_stiffness_coeff=mock_soln.virtual_boundary_stiffness_coeff,
@@ -204,9 +249,14 @@ def test_compute_lag_grid_velocity_mismatch_field(grid_dim, n_values, precision)
         dx=mock_soln.dx,
         num_lag_nodes=mock_soln.num_lag_nodes,
         real_t=mock_soln.real_t,
+        field_type=field_type,
     )
-
-    lag_grid_velocity_field = np.ones((grid_dim, mock_soln.num_lag_nodes), dtype=real_t)
+    if field_type == "scalar":
+        lag_grid_velocity_field = np.ones((mock_soln.num_lag_nodes), dtype=real_t)
+    else:
+        lag_grid_velocity_field = np.ones(
+            (grid_dim, mock_soln.num_lag_nodes), dtype=real_t
+        )
     virtual_boundary_forcing.lag_grid_flow_velocity_field = (
         real_t(3) * lag_grid_velocity_field
     )
@@ -227,14 +277,16 @@ def test_compute_lag_grid_velocity_mismatch_field(grid_dim, n_values, precision)
 @pytest.mark.parametrize("precision", ["single", "double"])
 @pytest.mark.parametrize("grid_dim", [2, 3])
 @pytest.mark.parametrize("n_values", [16])
+@pytest.mark.parametrize("field_type", ["scalar", "vector"])
 def test_update_lag_grid_position_mismatch_field_via_euler_forward(
-    grid_dim, n_values, precision
+    grid_dim, n_values, precision, field_type: Literal["scalar", "vector"]
 ):
     real_t = get_real_t(precision)
     mock_soln = MockVirtualBoundaryForcingSolution(
         grid_size=n_values,
         grid_dim=grid_dim,
         precision=precision,
+        field_type=field_type,
     )
     virtual_boundary_forcing = VirtualBoundaryForcing(
         virtual_boundary_stiffness_coeff=mock_soln.virtual_boundary_stiffness_coeff,
@@ -243,6 +295,7 @@ def test_update_lag_grid_position_mismatch_field_via_euler_forward(
         dx=mock_soln.dx,
         num_lag_nodes=mock_soln.num_lag_nodes,
         real_t=mock_soln.real_t,
+        field_type=field_type,
     )
 
     virtual_boundary_forcing.lag_grid_position_mismatch_field[...] = real_t(1.0)
@@ -267,12 +320,16 @@ def test_update_lag_grid_position_mismatch_field_via_euler_forward(
 @pytest.mark.parametrize("precision", ["single", "double"])
 @pytest.mark.parametrize("grid_dim", [2, 3])
 @pytest.mark.parametrize("n_values", [16])
-def test_compute_lag_grid_forcing_field(grid_dim, n_values, precision):
+@pytest.mark.parametrize("field_type", ["scalar", "vector"])
+def test_compute_lag_grid_forcing_field(
+    grid_dim, n_values, precision, field_type: Literal["scalar", "vector"]
+):
     real_t = get_real_t(precision)
     mock_soln = MockVirtualBoundaryForcingSolution(
         grid_size=n_values,
         grid_dim=grid_dim,
         precision=precision,
+        field_type=field_type,
     )
     virtual_boundary_forcing = VirtualBoundaryForcing(
         virtual_boundary_stiffness_coeff=mock_soln.virtual_boundary_stiffness_coeff,
@@ -281,6 +338,7 @@ def test_compute_lag_grid_forcing_field(grid_dim, n_values, precision):
         dx=mock_soln.dx,
         num_lag_nodes=mock_soln.num_lag_nodes,
         real_t=mock_soln.real_t,
+        field_type=field_type,
     )
 
     virtual_boundary_forcing.lag_grid_position_mismatch_field[...] = real_t(1.0)
@@ -306,11 +364,15 @@ def test_compute_lag_grid_forcing_field(grid_dim, n_values, precision):
 @pytest.mark.parametrize("precision", ["single", "double"])
 @pytest.mark.parametrize("grid_dim", [2, 3])
 @pytest.mark.parametrize("n_values", [16])
-def test_compute_interaction_force_on_lag_grid(grid_dim, n_values, precision):
+@pytest.mark.parametrize("field_type", ["scalar", "vector"])
+def test_compute_interaction_force_on_lag_grid(
+    grid_dim, n_values, precision, field_type: Literal["scalar", "vector"]
+):
     mock_soln = MockVirtualBoundaryForcingSolution(
         grid_size=n_values,
         grid_dim=grid_dim,
         precision=precision,
+        field_type=field_type,
     )
     mock_soln.compute_interaction_step_solution()
     virtual_boundary_forcing = VirtualBoundaryForcing(
@@ -321,6 +383,7 @@ def test_compute_interaction_force_on_lag_grid(grid_dim, n_values, precision):
         num_lag_nodes=mock_soln.num_lag_nodes,
         real_t=mock_soln.real_t,
         enable_eul_grid_forcing_reset=False,
+        field_type=field_type,
     )
     virtual_boundary_forcing.compute_interaction_force_on_lag_grid(
         eul_grid_velocity_field=mock_soln.eul_grid_velocity_field,
@@ -335,14 +398,16 @@ def test_compute_interaction_force_on_lag_grid(grid_dim, n_values, precision):
 @pytest.mark.parametrize("precision", ["single", "double"])
 @pytest.mark.parametrize("grid_dim", [2, 3])
 @pytest.mark.parametrize("n_values", [16])
+@pytest.mark.parametrize("field_type", ["scalar", "vector"])
 def test_compute_interaction_without_eul_grid_forcing_reset(
-    grid_dim, n_values, precision
+    grid_dim, n_values, precision, field_type: Literal["scalar", "vector"]
 ):
     real_t = get_real_t(precision)
     mock_soln = MockVirtualBoundaryForcingSolution(
         grid_size=n_values,
         grid_dim=grid_dim,
         precision=precision,
+        field_type=field_type,
     )
     mock_soln.compute_interaction_step_solution()
     virtual_boundary_forcing = VirtualBoundaryForcing(
@@ -353,8 +418,12 @@ def test_compute_interaction_without_eul_grid_forcing_reset(
         num_lag_nodes=mock_soln.num_lag_nodes,
         real_t=mock_soln.real_t,
         enable_eul_grid_forcing_reset=False,
+        field_type=field_type,
     )
-    eul_grid_velocity_shape = (grid_dim,) + (n_values,) * grid_dim
+    if field_type == "scalar":
+        eul_grid_velocity_shape = (n_values,) * grid_dim
+    else:
+        eul_grid_velocity_shape = (grid_dim,) + (n_values,) * grid_dim
     eul_grid_forcing_field = np.zeros(eul_grid_velocity_shape, dtype=real_t)
     virtual_boundary_forcing.compute_interaction_forcing(
         eul_grid_forcing_field=eul_grid_forcing_field,
@@ -373,12 +442,16 @@ def test_compute_interaction_without_eul_grid_forcing_reset(
 @pytest.mark.parametrize("precision", ["single", "double"])
 @pytest.mark.parametrize("grid_dim", [2, 3])
 @pytest.mark.parametrize("n_values", [16])
-def test_compute_interaction_with_eul_grid_forcing_reset(grid_dim, n_values, precision):
+@pytest.mark.parametrize("field_type", ["scalar", "vector"])
+def test_compute_interaction_with_eul_grid_forcing_reset(
+    grid_dim, n_values, precision, field_type: Literal["scalar", "vector"]
+):
     real_t = get_real_t(precision)
     mock_soln = MockVirtualBoundaryForcingSolution(
         grid_size=n_values,
         grid_dim=grid_dim,
         precision=precision,
+        field_type=field_type,
     )
     mock_soln.compute_interaction_step_solution()
     virtual_boundary_forcing = VirtualBoundaryForcing(
@@ -390,8 +463,12 @@ def test_compute_interaction_with_eul_grid_forcing_reset(grid_dim, n_values, pre
         real_t=mock_soln.real_t,
         enable_eul_grid_forcing_reset=True,
         num_threads=psutil.cpu_count(logical=False),
+        field_type=field_type,
     )
-    eul_grid_velocity_shape = (grid_dim,) + (n_values,) * grid_dim
+    if field_type == "scalar":
+        eul_grid_velocity_shape = (n_values,) * grid_dim
+    else:
+        eul_grid_velocity_shape = (grid_dim,) + (n_values,) * grid_dim
     eul_grid_forcing_field = np.random.rand(*eul_grid_velocity_shape).astype(real_t)
     virtual_boundary_forcing.compute_interaction_forcing(
         eul_grid_forcing_field=eul_grid_forcing_field,
@@ -410,12 +487,16 @@ def test_compute_interaction_with_eul_grid_forcing_reset(grid_dim, n_values, pre
 @pytest.mark.parametrize("precision", ["single", "double"])
 @pytest.mark.parametrize("grid_dim", [2, 3])
 @pytest.mark.parametrize("n_values", [16])
-def test_time_step(grid_dim, n_values, precision):
+@pytest.mark.parametrize("field_type", ["scalar", "vector"])
+def test_time_step(
+    grid_dim, n_values, precision, field_type: Literal["scalar", "vector"]
+):
     real_t = get_real_t(precision)
     mock_soln = MockVirtualBoundaryForcingSolution(
         grid_size=n_values,
         grid_dim=grid_dim,
         precision=precision,
+        field_type=field_type,
     )
     virtual_boundary_forcing = VirtualBoundaryForcing(
         virtual_boundary_stiffness_coeff=mock_soln.virtual_boundary_stiffness_coeff,
@@ -424,6 +505,7 @@ def test_time_step(grid_dim, n_values, precision):
         dx=mock_soln.dx,
         num_lag_nodes=mock_soln.num_lag_nodes,
         real_t=mock_soln.real_t,
+        field_type=field_type,
     )
 
     virtual_boundary_forcing.lag_grid_position_mismatch_field[...] = real_t(1.0)

--- a/tests/test_simulator/test_immersed_body/rigid_body/test_rigid_body_flow_interaction.py
+++ b/tests/test_simulator/test_immersed_body/rigid_body/test_rigid_body_flow_interaction.py
@@ -30,3 +30,27 @@ def test_rigid_body_flow_interaction():
         cylinder_flow_interactor.body_flow_torques, np.zeros((rigid_body_dim, 1))
     )
     assert isinstance(cylinder_flow_interactor.forcing_grid, forcing_grid_cls)
+
+
+def test_rigid_body_flow_interaction_for_scalar_field():
+    cylinder = mock_2d_cylinder()
+    grid_size = (16, 16)
+    forcing_grid_cls = sps.CircularCylinderConstantTemperatureForcingGrid
+    cylinder_flow_interactor = sps.RigidBodyFlowInteraction(
+        rigid_body=cylinder,
+        eul_grid_forcing_field=np.zeros(grid_size),
+        eul_grid_velocity_field=np.zeros(grid_size),
+        virtual_boundary_stiffness_coeff=1.0,
+        virtual_boundary_damping_coeff=1.0,
+        dx=1.0,
+        grid_dim=2,
+        real_t=get_real_t(),
+        field_type="scalar",
+        forcing_grid_cls=forcing_grid_cls,
+        num_forcing_points=16,
+        cylinder_temperature=np.abs(np.random.randn()),
+    )
+
+    assert cylinder_flow_interactor.field_type == "scalar"
+
+    assert isinstance(cylinder_flow_interactor.forcing_grid, forcing_grid_cls)

--- a/tests/test_simulator/test_immersed_body/rigid_body/test_rigid_body_forcing_grids.py
+++ b/tests/test_simulator/test_immersed_body/rigid_body/test_rigid_body_forcing_grids.py
@@ -157,6 +157,69 @@ def test_circular_cylinder_grid_spacing(num_forcing_points):
     assert correct_max_grid_spacing == max_grid_spacing
 
 
+@pytest.mark.parametrize("num_forcing_points", [8, 16])
+@pytest.mark.parametrize("cylinder_temperature", [10.0, 20.0, 30.0])
+def test_circular_cylinder_constant_temperature_forcing_grid_initialization(
+    num_forcing_points, cylinder_temperature
+):
+    cylinder = mock_2d_cylinder()
+    grid_dim = 2
+    # Here we are assuming that CircularCylinderForcingGrid is tested in previous tests, and we use it to compare
+    # the surface grid positions.
+    correct_circ_cyl_forcing_grid = sps.CircularCylinderForcingGrid(
+        grid_dim=grid_dim,
+        rigid_body=cylinder,
+        num_forcing_points=num_forcing_points,
+    )
+    test_circ_cyl_forcing_grid = sps.CircularCylinderConstantTemperatureForcingGrid(
+        grid_dim=grid_dim,
+        rigid_body=cylinder,
+        num_forcing_points=num_forcing_points,
+        cylinder_temperature=cylinder_temperature,
+    )
+
+    np.testing.assert_allclose(
+        correct_circ_cyl_forcing_grid.position_field,
+        test_circ_cyl_forcing_grid.position_field,
+        atol=get_test_tol(precision="double"),
+    )
+
+    # Compute correct velocity field. This is a scalar size of number of forcing points and values are same as cylinder
+    # temperature.
+    correct_cylinder_velocity = cylinder_temperature * np.ones(num_forcing_points)
+
+    np.testing.assert_allclose(
+        correct_cylinder_velocity,
+        test_circ_cyl_forcing_grid.velocity_field,
+        atol=get_test_tol(precision="double"),
+    )
+
+
+@pytest.mark.parametrize("num_forcing_points", [8, 16])
+@pytest.mark.parametrize("cylinder_temperature", [10.0, 20.0, 30.0])
+def test_circular_cylinder_constant_temperature_forcing_grid_validity_of_override_methods(
+    num_forcing_points, cylinder_temperature
+):
+    cylinder = mock_2d_cylinder()
+    grid_dim = 2
+
+    test_circ_cyl_forcing_grid = sps.CircularCylinderConstantTemperatureForcingGrid(
+        grid_dim=grid_dim,
+        rigid_body=cylinder,
+        num_forcing_points=num_forcing_points,
+        cylinder_temperature=cylinder_temperature,
+    )
+    correct_cylinder_velocity = cylinder_temperature * np.ones(num_forcing_points)
+
+    # Call the method and check if values are changed or not.
+    test_circ_cyl_forcing_grid.compute_lag_grid_velocity_field()
+    np.testing.assert_allclose(
+        correct_cylinder_velocity,
+        test_circ_cyl_forcing_grid.velocity_field,
+        atol=get_test_tol(precision="double"),
+    )
+
+
 def mock_3d_sphere():
     """Returns a mock 3D sphere (from elastica) for testing"""
     sphere_radius = 0.1

--- a/tests/test_simulator/test_immersed_body/test_immersed_body_flow_interaction.py
+++ b/tests/test_simulator/test_immersed_body/test_immersed_body_flow_interaction.py
@@ -131,3 +131,65 @@ def test_immersed_body_interactor_get_grid_deviation_error_l2_norm():
     grid_dim = cylinder_flow_interactor.grid_dim
     ref_grid_dev_error_l2_norm = fixed_val * np.sqrt(grid_dim)
     np.testing.assert_allclose(grid_dev_error_l2_norm, ref_grid_dev_error_l2_norm)
+
+
+@pytest.mark.xfail(raises=AssertionError)
+@pytest.mark.parametrize(
+    "incompatible_types", [("scalar", sps.CircularCylinderForcingGrid)]
+)
+def test_immersed_body_interactor_scalar_field_type_and_forcing_grid_incompatible(
+    incompatible_types,
+):
+    num_forcing_points = 16
+    grid_dim = 2
+    cylinder = mock_2d_cylinder()
+    grid_size = (16,) * grid_dim
+    eul_grid_velocity_field = np.random.rand(grid_dim, *grid_size)
+    eul_grid_forcing_field = np.zeros_like(eul_grid_velocity_field)
+    # chosen so that cylinder lies within domain
+    dx = cylinder.length / 4.0
+    sps.RigidBodyFlowInteraction(
+        rigid_body=cylinder,
+        eul_grid_forcing_field=eul_grid_forcing_field,
+        eul_grid_velocity_field=eul_grid_velocity_field,
+        virtual_boundary_stiffness_coeff=1.0,
+        virtual_boundary_damping_coeff=1.0,
+        dx=dx,
+        grid_dim=grid_dim,
+        field_type=incompatible_types[0],
+        real_t=get_real_t(),
+        forcing_grid_cls=incompatible_types[1],
+        num_forcing_points=num_forcing_points,
+    )
+
+
+@pytest.mark.xfail(raises=AssertionError)
+@pytest.mark.parametrize(
+    "incompatible_types",
+    [("vector", sps.CircularCylinderConstantTemperatureForcingGrid)],
+)
+def test_immersed_body_interactor_vector_field_type_and_forcing_grid_incompatible(
+    incompatible_types,
+):
+    num_forcing_points = 16
+    grid_dim = 2
+    cylinder = mock_2d_cylinder()
+    grid_size = (16,) * grid_dim
+    eul_grid_velocity_field = np.random.rand(grid_dim, *grid_size)
+    eul_grid_forcing_field = np.zeros_like(eul_grid_velocity_field)
+    # chosen so that cylinder lies within domain
+    dx = cylinder.length / 4.0
+    sps.RigidBodyFlowInteraction(
+        rigid_body=cylinder,
+        eul_grid_forcing_field=eul_grid_forcing_field,
+        eul_grid_velocity_field=eul_grid_velocity_field,
+        virtual_boundary_stiffness_coeff=1.0,
+        virtual_boundary_damping_coeff=1.0,
+        dx=dx,
+        grid_dim=grid_dim,
+        field_type=incompatible_types[0],
+        real_t=get_real_t(),
+        forcing_grid_cls=incompatible_types[1],
+        num_forcing_points=num_forcing_points,
+        cylinder_temperature=1,
+    )


### PR DESCRIPTION
This pull request expands the functionality of the virtual boundary method implemented in Sopht. It introduces support for scalar fields, enabling the simulation and manipulation of variables like temperature within the framework.

Solves #138 